### PR TITLE
修复tx源翻译歌词解析不全的问题

### DIFF
--- a/src/renderer/utils/musicSdk/tx/lyric.js
+++ b/src/renderer/utils/musicSdk/tx/lyric.js
@@ -148,12 +148,12 @@ const parseTools = {
       const words = line.replace(timeTagRxp, '')
       if (!words.trim()) return
       const tag = result[0].replace(/\d]/, '').replace(this.rxps.timeLabelFixRxp, '')
-
+      let mstag = result[0].replace(/\d]/, '').split('.')[1]
       while (lrcLines.length) {
         const lrcLine = lrcLines.shift()
         const lrcLineResult = timeTagRxp.exec(lrcLine)
         if (!lrcLineResult) continue
-        if (lrcLineResult[0].includes(tag)) {
+        if (lrcLineResult[0].includes(tag) || Math.abs(lrcLineResult[0].replace(/\d]/, '').split('.')[1] - mstag) < 100) {
           newLrc.push(line.replace(timeTagRxp, lrcLineResult[0]))
           break
         }


### PR DESCRIPTION
之前：
![image](https://github.com/lyswhut/lx-music-desktop/assets/94218819/51b4aaf4-0ad9-4aaf-add1-61f45e228f70)

之后：
![image](https://github.com/lyswhut/lx-music-desktop/assets/94218819/08fdd0cc-454e-4eed-ba21-d77f50dccf77)
