### PR TITLE
修改下载相关默认设置

### DIFF
--- a/src/common/defaultSetting.ts
+++ b/src/common/defaultSetting.ts
@@ -101,8 +101,8 @@ const defaultSetting: LX.AppSetting = {
   'list.addMusicLocationType': 'top',
   'list.actionButtonsVisible': false,
 
-  'download.enable': false,
-  'download.savePath': join(homedir(), 'Desktop'),
+  'download.enable': true,
+  'download.savePath': join(homedir(), 'Downloads'),
   'download.fileName': '歌名 - 歌手',
   'download.maxDownloadNum': 3,
   'download.skipExistFile': true,
@@ -111,8 +111,8 @@ const defaultSetting: LX.AppSetting = {
   'download.isDownloadRLrc': false,
   'download.lrcFormat': 'utf8',
   'download.isEmbedPic': true,
-  'download.isEmbedLyric': false,
-  'download.isEmbedLyricT': false,
+  'download.isEmbedLyric': true,
+  'download.isEmbedLyricT': true,
   'download.isEmbedLyricR': false,
   'download.isUseOtherSource': false,
 


### PR DESCRIPTION
默认启用下载。
修改下载默认文件夹为'$HOME/Downloads'
默认启用歌词与翻译歌词嵌入。
这样更偏向于大众化，减少单独配置。

特别是下载功能没有必要单独设立一个开关。