### PR TITLE
修复 Linux 端 hostnamectl 命令不可用时无法与手机端同步的问题

### DIFF
--- a/src/main/modules/sync/utils.ts
+++ b/src/main/modules/sync/utils.ts
@@ -31,14 +31,15 @@ export const getComputerName = () => {
       name = process.env.COMPUTERNAME
       break
     case 'darwin':
-      name = cp.execSync('scutil --get ComputerName').toString().trim()
+      try {
+        name = cp.execSync('scutil --get ComputerName').toString().trim()
+      } catch {}
       break
     case 'linux':
+      // Don't fail even if hostnamectl is unavailable
       try {
         name = cp.execSync('hostnamectl --pretty').toString().trim()
-      }
-      // Don't fail even if hostnamectl is unavailable
-      finally { break }
+      } catch {}
   }
   if (!name) name = os.hostname()
   return name

--- a/src/main/modules/sync/utils.ts
+++ b/src/main/modules/sync/utils.ts
@@ -34,8 +34,11 @@ export const getComputerName = () => {
       name = cp.execSync('scutil --get ComputerName').toString().trim()
       break
     case 'linux':
-      name = cp.execSync('hostnamectl --pretty').toString().trim()
-      break
+      try {
+        name = cp.execSync('hostnamectl --pretty').toString().trim()
+      }
+      // Don't fail even if hostnamectl is unavailable
+      finally { break }
   }
   if (!name) name = os.hostname()
   return name


### PR DESCRIPTION
`hostnamectl` 命令是 systemd 的一部分。在一些环境下，例如非 systemd 发行版或某些沙盒环境中，此命令可能不可用。目前 lx-music-desktop 在 Linux 端启用同步时会尝试通过 `hostnamectl --pretty` 来获取计算机名，在该命令执行**失败**时会导致手极端无法启用同步。此 PR 将执行此命令的代码放入 `try` 块中，使得在该命令未能正确执行的情况下也能回退到直接使用 `os.hostname()` 的方案。

不太熟悉 JS，临时照着 [MDN 的文档](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Statements/try...catch) 写的，如有写得不对的地方请指正😉