### PR TITLE
Fix edit theme dialog layout 3

### DIFF
--- a/src/lang/en-us.json
+++ b/src/lang/en-us.json
@@ -684,7 +684,7 @@
   "theme_edit_modal__primary": "Theme Color",
   "theme_edit_modal__remove": "Remove",
   "theme_edit_modal__remove_tip": "Do you really want to remove this theme?",
-  "theme_edit_modal__save_new": "Save New",
+  "theme_edit_modal__save_new": "Copy",
   "theme_edit_modal__select_bg_file": "Choose a background image",
   "theme_edit_modal__title": "Edit Theme",
   "theme_green": "Green",

--- a/src/renderer/views/Setting/components/ThemeEditModal/index.vue
+++ b/src/renderer/views/Setting/components/ThemeEditModal/index.vue
@@ -105,8 +105,10 @@
           <base-input v-model="themeName" :class="$style.input" :placeholder="$t('theme_selector_modal__theme_name')" />
           <div :class="$style.subContent" style="flex-wrap: wrap;">
             <base-checkbox id="theme_edit_modal__dark" v-model="isDark" :class="$style.checkbox" :label="$t('theme_edit_modal__dark')" @change="handleDark" />
-            <base-checkbox id="theme_edit_modal__dark_font" v-model="isDarkFont" :class="$style.checkbox" :label="$t('theme_edit_modal__dark_font')" @change="handleDarkFont" />
-            <base-checkbox id="theme_edit_modal__preview" v-model="preview" :class="$style.checkbox" :label="$t('theme_edit_modal__preview')" @change="handlePreview" />
+            <div :class="$style.subContent" style="flex-wrap: wrap;">
+              <base-checkbox id="theme_edit_modal__dark_font" v-model="isDarkFont" :class="$style.checkbox" :label="$t('theme_edit_modal__dark_font')" @change="handleDarkFont" />
+              <base-checkbox id="theme_edit_modal__preview" v-model="preview" :class="$style.checkbox" :label="$t('theme_edit_modal__preview')" @change="handlePreview" />
+            </div>
           </div>
         </div>
         <div :class="$style.subContent" style="flex: none;">
@@ -776,14 +778,14 @@ export default {
     display: flex;
     flex-flow: row nowrap;
     align-items: center;
-    gap: 15px;
+    gap: 10px;
   }
 
   .checkbox {
     flex: none;
   }
   .input {
-    min-width: 0;
+    max-width: 150px;
     flex: 0 1 auto;
   }
 }


### PR DESCRIPTION
In a previous PR, I ended up testing only Segoe UI and forgot to test the other fonts. 😢 

Now enhance the robustness of this dialog by adjusting the translation and styling again.

<details>
<summary>Before</summary>

*Smaller window size, Oversize font size, Sarasa UI*
![1](https://github.com/user-attachments/assets/bcdd64fb-20cd-4ed7-909d-42f9bbc7b295)


*Smaller window size, Oversize font size, Source Han Serif*
![2](https://github.com/user-attachments/assets/d168d82d-21f4-4239-ab36-b178bc37cdd6)

</details>

<details>
<summary>After</summary>

*Smaller window size, Oversize font size, Sarasa UI*
![3](https://github.com/user-attachments/assets/29fd4045-bc96-4ebe-962b-b124a7b0ca0b)

*Smaller window size, Oversize font size, Source Han Serif*
![4](https://github.com/user-attachments/assets/8a6882c8-b07f-4603-b7d6-7212c49446b1)

</details>