### PR TITLE
Disable randomize popup animation option when animation is not turned on

### DIFF
--- a/src/renderer/views/Setting/components/SettingBasic.vue
+++ b/src/renderer/views/Setting/components/SettingBasic.vue
@@ -5,7 +5,7 @@ dd
     .gap-top
       base-checkbox(id="setting_show_animate" :model-value="appSetting['common.isShowAnimation']" :label="$t('setting__basic_show_animation')" @update:model-value="updateSetting({'common.isShowAnimation': $event})")
     .gap-top
-      base-checkbox(id="setting_animate" :model-value="appSetting['common.randomAnimate']" :label="$t('setting__basic_animation')" @update:model-value="updateSetting({'common.randomAnimate': $event})")
+      base-checkbox(id="setting_animate" :disabled="!appSetting['common.isShowAnimation']" :model-value="appSetting['common.randomAnimate']" :label="$t('setting__basic_animation')" @update:model-value="updateSetting({'common.randomAnimate': $event})")
     .gap-top
       base-checkbox(id="setting_start_in_fullscreen" :model-value="appSetting['common.startInFullscreen']" :label="$t('setting__basic_start_in_fullscreen')" @update:model-value="updateSetting({'common.startInFullscreen': $event})")
     .gap-top


### PR DESCRIPTION
This option has no real purpose if "Show switch animation" is not turned on. So I mimicked the option about lyrics in the download settings page.

<details>
<summary>🟥 Before</summary>

![1-1](https://github.com/user-attachments/assets/422edbe0-a6cb-4ef8-93b9-4ea6ce90f4da)

</details>

<details>
<summary>🔵 After</summary>

![1-2](https://github.com/user-attachments/assets/13eec4d6-af53-461a-9acc-26267f0f059a)

</details>