### PR TITLE
Disable rounded corners for lyric window

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -14,6 +14,8 @@ import { openDirInExplorer } from '@common/utils/electron'
 
 export const initGlobalData = () => {
   const envParams = parseEnvParams()
+  envParams.cmdParams.dt = !!envParams.cmdParams.dt
+
   global.envParams = {
     cmdParams: envParams.cmdParams,
     deeplink: envParams.deeplink,

--- a/src/main/modules/userApi/main.ts
+++ b/src/main/modules/userApi/main.ts
@@ -77,6 +77,7 @@ export const createWindow = async(userApi: LX.UserApi.UserApiInfo) => {
     minimizable: false,
     maximizable: false,
     fullscreenable: false,
+    roundedCorners: false,
     hasShadow: false,
     show: false,
     webPreferences: {

--- a/src/main/modules/winLyric/main.ts
+++ b/src/main/modules/winLyric/main.ts
@@ -127,6 +127,7 @@ export const createWindow = () => {
     minimizable: false,
     maximizable: false,
     fullscreenable: false,
+    roundedCorners: false,
     show: false,
     alwaysOnTop: isAlwaysOnTop,
     skipTaskbar: !isShowTaskbar,

--- a/src/main/modules/winMain/main.ts
+++ b/src/main/modules/winMain/main.ts
@@ -87,7 +87,7 @@ export const createWindow = () => {
     resizable: false,
     maximizable: false,
     fullscreenable: true,
-    roundedCorners: false,
+    roundedCorners: global.envParams.cmdParams.dt,
     show: false,
     webPreferences: {
       session: ses,
@@ -109,7 +109,7 @@ export const createWindow = () => {
   browserWindow = new BrowserWindow(options)
 
   const winURL = process.env.NODE_ENV !== 'production' ? 'http://localhost:9080' : `file://${path.join(encodePath(__dirname), 'index.html')}`
-  void browserWindow.loadURL(winURL + `?os=${getPlatform()}&dt=${!!global.envParams.cmdParams.dt}&dark=${shouldUseDarkColors}&theme=${encodeURIComponent(JSON.stringify(theme))}`)
+  void browserWindow.loadURL(winURL + `?os=${getPlatform()}&dt=${global.envParams.cmdParams.dt}&dark=${shouldUseDarkColors}&theme=${encodeURIComponent(JSON.stringify(theme))}`)
 
   winEvent()
 


### PR DESCRIPTION
Ensure that the lyric window looks the same on Windows 11 as it does on other systems.

Ref: https://github.com/electron/electron/issues/46468

Resolves #2355