### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/beta-pack.yml
+++ b/.github/workflows/beta-pack.yml
@@ -14,7 +14,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Check out git repository
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
 
   #     - name: Install Node.js
   #       uses: actions/setup-node@v4
@@ -46,7 +46,7 @@ jobs:
     # needs: CheckCode
     steps:
       - name: Check out git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get npm cache directory
         shell: pwsh
@@ -65,7 +65,7 @@ jobs:
       - name: Build Package Setup x64
         run: npm run pack:win:setup:x64
       - name: Upload Artifact Setup x64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lx-music-desktop-x64-Setup
           path: build/*-x64-Setup.exe
@@ -73,7 +73,7 @@ jobs:
       - name: Build Package 7z x64
         run: npm run pack:win:7z:x64
       - name: Upload Artifact 7z x64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lx-music-desktop-win_x64-green
           path: build/*win_x64-green.7z
@@ -81,7 +81,7 @@ jobs:
       - name: Build Package Setup arm64
         run: npm run pack:win:setup:arm64
       - name: Upload Artifact Setup arm64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lx-music-desktop-arm64-Setup
           path: build/*-arm64-Setup.exe
@@ -89,7 +89,7 @@ jobs:
       - name: Build Package 7z arm64
         run: npm run pack:win:7z:arm64
       - name: Upload Artifact 7z arm64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lx-music-desktop-win_arm64-green
           path: build/*win_arm64-green.7z
@@ -104,7 +104,7 @@ jobs:
       - name: Build Package win7 Setup x64
         run: npm run pack:win7:setup:x64
       - name: Upload Artifact win7 Setup x64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lx-music-desktop-win7_x64-Setup
           path: build/*win7_x64-Setup.exe
@@ -112,7 +112,7 @@ jobs:
       - name: Build Package win7 7z x64
         run: npm run pack:win7:7z:x64
       - name: Upload Artifact win7 7z x64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lx-music-desktop-win7_x64-green
           path: build/*win7_x64-green.7z
@@ -120,7 +120,7 @@ jobs:
       - name: Build Package win7 7z x86
         run: npm run pack:win7:7z:x86
       - name: Upload Artifact win7 7z x86
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lx-music-desktop-win7_x86-green
           path: build/*win7_x86-green.7z
@@ -136,7 +136,7 @@ jobs:
     # needs: CheckCode
     steps:
       - name: Check out git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install python setuptools
         run: brew install python-setuptools
@@ -161,14 +161,14 @@ jobs:
           npm run pack:mac:dmg:arm64
 
       - name: Upload Artifact dmg
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lx-music-desktop-mac-dmg
           path: |
             build/*.dmg
             !build/*-arm64.dmg
       - name: Upload Artifact dmg
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lx-music-desktop-mac-dmg-arm64
           path: build/*-arm64.dmg
@@ -187,7 +187,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y rpm libarchive-tools
 
       - name: Check out git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get npm cache directory
         shell: bash
@@ -206,7 +206,7 @@ jobs:
       - name: Build Package deb amd64
         run: npm run pack:linux:deb:amd64
       - name: Upload Artifact deb amd64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lx-music-desktop-deb-amd64
           path: build/*_amd64.deb
@@ -214,7 +214,7 @@ jobs:
       - name: Build Package deb arm64
         run: npm run pack:linux:deb:arm64
       - name: Upload Artifact deb arm64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lx-music-desktop-deb-arm64
           path: build/*_arm64.deb
@@ -222,7 +222,7 @@ jobs:
       - name: Build Package deb armv7l
         run: npm run pack:linux:deb:armv7l
       - name: Upload Artifact deb armv7l
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lx-music-desktop-deb-armv7l
           path: build/*_armv7l.deb
@@ -230,7 +230,7 @@ jobs:
       - name: Build Package x64 appImage
         run: npm run pack:linux:appImage
       - name: Upload Artifact x64 appImage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lx-music-desktop-x64-appImage
           path: build/*_x64.AppImage
@@ -238,7 +238,7 @@ jobs:
       - name: Build Package x64 rpm
         run: npm run pack:linux:rpm
       - name: Upload Artifact x64 rpm
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lx-music-desktop-x64-rpm
           path: build/*.x64.rpm
@@ -246,7 +246,7 @@ jobs:
       - name: Build Package x64 pacman
         run: npm run pack:linux:pacman
       - name: Upload Artifact x64 pacman
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lx-music-desktop-x64-pacman
           path: build/*_x64.pacman

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Check out git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 

--- a/.github/workflows/publish-version-info.yml
+++ b/.github/workflows/publish-version-info.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.PAT }}
           repository: lyswhut/lx-music-desktop-version-info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Check out git repository
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
 
   #     - name: Install Node.js
   #       uses: actions/setup-node@v4
@@ -46,7 +46,7 @@ jobs:
     # needs: CheckCode
     steps:
       - name: Check out git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get npm cache directory
         shell: pwsh
@@ -87,7 +87,7 @@ jobs:
     # needs: CheckCode
     steps:
       - name: Check out git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get npm cache directory
         shell: pwsh
@@ -128,7 +128,7 @@ jobs:
     # needs: CheckCode
     steps:
       - name: Check out git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install python3 setuptools
         run: brew install python-setuptools
@@ -171,7 +171,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y rpm libarchive-tools
 
       - name: Check out git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get npm cache directory
         shell: bash


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `peter-evans/repository-dispatch` from `v2` to `v4` in `.github/workflows/publish-version-info.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/build-test.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/beta-pack.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/release.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/build-test.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/beta-pack.yml`
