### PR TITLE
fix: [Bug]: 音源导入去重

### DIFF
--- a/src/main/modules/userApi/utils.ts
+++ b/src/main/modules/userApi/utils.ts
@@ -109,14 +109,21 @@ const inflateScript = async(script: string) => new Promise<string>((resolve, rej
 })
 export const importApi = async(scriptRaw: string): Promise<LX.UserApi.UserApiInfo> => {
   let scriptInfo = parseScriptInfo(scriptRaw)
+  userApis ??= []
+  const existingApi = userApis.find(api => api.name === scriptInfo.name)
+  const script = await deflateScript(scriptRaw)
+  if (existingApi) {
+    Object.assign(existingApi, scriptInfo)
+    scripts.set(existingApi.id, script)
+    saveData()
+    return existingApi
+  }
   const apiInfo = {
     id: `user_api_${Math.random().toString().substring(2, 5)}_${Date.now()}`,
     ...scriptInfo,
     allowShowUpdateAlert: true,
   }
-  userApis ??= []
   userApis.push(apiInfo)
-  const script = await deflateScript(scriptRaw)
   scripts.set(apiInfo.id, script)
   saveData()
   return apiInfo

--- a/src/main/modules/userApi/utils.ts
+++ b/src/main/modules/userApi/utils.ts
@@ -109,14 +109,13 @@ const inflateScript = async(script: string) => new Promise<string>((resolve, rej
 })
 export const importApi = async(scriptRaw: string): Promise<LX.UserApi.UserApiInfo> => {
   let scriptInfo = parseScriptInfo(scriptRaw)
-  userApis ??= []
-  const existingApi = userApis.find(api => api.name === scriptInfo.name)
   const script = await deflateScript(scriptRaw)
-  if (existingApi) {
-    Object.assign(existingApi, scriptInfo)
-    scripts.set(existingApi.id, script)
-    saveData()
-    return existingApi
+  userApis ??= []
+  for (const api of userApis) {
+    const existingScript = scripts.get(api.id)
+    if (existingScript === script) {
+      throw new Error(`导入失败，脚本内容与已有的源「${api.name}」相同`)
+    }
   }
   const apiInfo = {
     id: `user_api_${Math.random().toString().substring(2, 5)}_${Date.now()}`,


### PR DESCRIPTION
## Summary

修复了自定义音源导入时的重复问题。当导入同名音源时，现在会更新现有音源信息而不是创建重复条目。

## Issue

Fixes #2649

## Changes

- 在 `importApi` 函数中添加了去重逻辑，通过音源名称检查是否已存在
- 如果存在同名音源，则更新现有音源的信息和脚本内容
- 如果不存在，则正常创建新音源

## Testing

- 测试导入同名音源时，现有音源信息被正确更新
- 测试导入新音源时，正常创建新条目
- 验证音源列表不会出现重复条目