### PR TITLE
fix(mac): 修复 Mac 睡眠导致音乐播放中断的问题

### DIFF
--- a/src/main/utils/index.ts
+++ b/src/main/utils/index.ts
@@ -1,4 +1,4 @@
-import { encodePath, isUrl, throttle } from '@common/utils'
+import { encodePath, isUrl, throttle, isMac } from '@common/utils'
 import migrateSetting from '@common/utils/migrateSetting'
 import getStore from '@main/utils/store'
 import { STORE_NAMES, URL_SCHEME_RXP } from '@common/constants'
@@ -134,7 +134,7 @@ export const updateSetting = (setting?: Partial<LX.AppSetting>, isInit: boolean 
 /**
  * 初始化设置
  */
-export const initSetting = async() => {
+export const initSetting = async () => {
   const electronStore_config = getStore(STORE_NAMES.APP_SETTINGS)
 
   let setting = electronStore_config.get('setting') as LX.AppSetting | undefined
@@ -154,7 +154,7 @@ export const initSetting = async() => {
 /**
  * 初始化快捷键设置
  */
-export const initHotKey = async() => {
+export const initHotKey = async () => {
   const electronStore_hotKey = getStore(STORE_NAMES.HOTKEY)
 
   let localConfig = electronStore_hotKey.get('local') as LX.HotKeyConfig | null
@@ -293,7 +293,7 @@ export const setPowerSaveBlocker = (enabled: boolean) => {
   let isEnabled = powerSaveBlockerId != null && powerSaveBlocker.isStarted(powerSaveBlockerId)
   if (enabled) {
     if (isEnabled) return
-    powerSaveBlockerId = powerSaveBlocker.start('prevent-app-suspension')
+    powerSaveBlockerId = powerSaveBlocker.start(isMac ? 'prevent-display-sleep' : 'prevent-app-suspension')
   } else {
     if (!isEnabled) return
     powerSaveBlocker.stop(powerSaveBlockerId!)

--- a/src/main/utils/index.ts
+++ b/src/main/utils/index.ts
@@ -134,7 +134,7 @@ export const updateSetting = (setting?: Partial<LX.AppSetting>, isInit: boolean 
 /**
  * 初始化设置
  */
-export const initSetting = async () => {
+export const initSetting = async() => {
   const electronStore_config = getStore(STORE_NAMES.APP_SETTINGS)
 
   let setting = electronStore_config.get('setting') as LX.AppSetting | undefined
@@ -154,7 +154,7 @@ export const initSetting = async () => {
 /**
  * 初始化快捷键设置
  */
-export const initHotKey = async () => {
+export const initHotKey = async() => {
   const electronStore_hotKey = getStore(STORE_NAMES.HOTKEY)
 
   let localConfig = electronStore_hotKey.get('local') as LX.HotKeyConfig | null


### PR DESCRIPTION
## 描述
修复了在 Mac 系统开启“播放歌曲时阻止电脑休眠”选项后，电脑在息屏一段时间后仍然会睡眠，从而导致音乐中断的问题。

## 做了什么改动？
在 Mac 下将防睡眠策略由原来的 `prevent-app-suspension` 升级为 `prevent-display-sleep`。
因为 macOS 对于电源管理较严格（比如 App Nap 机制），仅使用阻止应用挂起锁在系统息屏后依然会被系统强制睡眠（音频切断），使用屏幕常亮锁能够切实兜底并保持系统活跃与正常播放。

## 测试与验证
* 系统平台：macOS ARM64
* 开启防休眠配置后，10分钟以上无操作且不人工干预情况下，Mac 的播放能正确维持且未中断。
