### PR TITLE
feat(#2731): 添加歌曲列表按歌名排序及字母索引功能

### DIFF
--- a/src/renderer/views/List/MusicList/components/LetterIndex.vue
+++ b/src/renderer/views/List/MusicList/components/LetterIndex.vue
@@ -1,0 +1,102 @@
+<template>
+  <div :class="$style.indexBar">
+    <div
+      v-for="letter in letters"
+      :key="letter"
+      :class="[$style.item, { [$style.active]: activeLetter === letter }]"
+      @click="handleClick(letter)"
+      @mouseenter="activeLetter = letter"
+      @mouseleave="activeLetter = ''"
+    >
+      {{ letter }}
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed } from '@common/utils/vueTools'
+import { groupByFirstLetter } from '../useLetterIndex'
+
+export default {
+  props: {
+    list: {
+      type: Array,
+      default: () => [],
+    },
+    sortState: {
+      type: String,
+      default: 'none',
+    },
+  },
+  emits: ['scroll-to'],
+  setup(props, { emit }) {
+    const activeLetter = ref('')
+
+    const letterGroups = computed(() => {
+      if (props.sortState === 'none' || !props.list.length) {
+        return { letters: [], groups: {} }
+      }
+      return groupByFirstLetter(props.list)
+    })
+
+    const letters = computed(() => {
+      const baseLetters = letterGroups.value.letters
+      if (props.sortState === 'desc') {
+        const hasHash = baseLetters[baseLetters.length - 1] === '#'
+        const letterPart = hasHash ? baseLetters.slice(0, -1) : baseLetters
+        return hasHash ? [...letterPart.reverse(), '#'] : [...letterPart].reverse()
+      }
+      return baseLetters
+    })
+
+    const handleClick = (letter) => {
+      const indices = letterGroups.value.groups[letter]
+      if (indices?.length) emit('scroll-to', indices[0])
+    }
+
+    return {
+      activeLetter,
+      letters,
+      handleClick,
+    }
+  },
+}
+</script>
+
+<style lang="less" module>
+.indexBar {
+  position: absolute;
+  right: 4px;
+  top: 0;
+  bottom: 0;
+  width: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  opacity: 0.6;
+  transition: opacity 0.2s ease;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
+.item {
+  font-size: 11px;
+  line-height: 1.2;
+  padding: 1px 2px;
+  cursor: pointer;
+  color: var(--color-font);
+  transition: color 0.15s ease, background-color 0.15s ease;
+  border-radius: 2px;
+  user-select: none;
+
+  &:hover,
+  &.active {
+    color: var(--color-primary);
+    background-color: var(--color-primary-light-600-alpha-100);
+  }
+}
+</style>

--- a/src/renderer/views/List/MusicList/index.vue
+++ b/src/renderer/views/List/MusicList/index.vue
@@ -5,7 +5,20 @@
         <thead>
           <tr v-if="actionButtonsVisible">
             <th class="num" style="width: 5%;">#</th>
-            <th class="nobreak">{{ $t('music_name') }}</th>
+            <th class="nobreak" style="display: flex; align-items: center; gap: 4px;">
+              {{ $t('music_name') }}
+              <button :class="[$style.sortBtn, { [$style.active]: sortState !== 'none' }]" title="按歌名排序" @click="toggleSort">
+                <svg v-if="sortState === 'none'" version="1.1" xmlns="http://www.w3.org/2000/svg" height="100%" viewBox="0 0 24 24">
+                  <path fill="currentColor" d="M7 10l5 5 5-5z" />
+                </svg>
+                <svg v-else-if="sortState === 'asc'" version="1.1" xmlns="http://www.w3.org/2000/svg" height="100%" viewBox="0 0 24 24">
+                  <path fill="currentColor" d="M7 14l5-5 5 5z" />
+                </svg>
+                <svg v-else version="1.1" xmlns="http://www.w3.org/2000/svg" height="100%" viewBox="0 0 24 24">
+                  <path fill="currentColor" d="M7 10l5 5 5-5z" />
+                </svg>
+              </button>
+            </th>
             <th class="nobreak" style="width: 22%;">{{ $t('music_singer') }}</th>
             <th class="nobreak" style="width: 22%;">{{ $t('music_album') }}</th>
             <th class="nobreak" style="width: 9%;">{{ $t('music_time') }}</th>
@@ -13,7 +26,20 @@
           </tr>
           <tr v-else>
             <th class="num" style="width: 5%;">#</th>
-            <th class="nobreak">{{ $t('music_name') }}</th>
+            <th class="nobreak" style="display: flex; align-items: center; gap: 4px;">
+              {{ $t('music_name') }}
+              <button :class="[$style.sortBtn, { [$style.active]: sortState !== 'none' }]" title="按歌名排序" @click="toggleSort">
+                <svg v-if="sortState === 'none'" version="1.1" xmlns="http://www.w3.org/2000/svg" height="100%" viewBox="0 0 24 24">
+                  <path fill="currentColor" d="M7 10l5 5 5-5z" />
+                </svg>
+                <svg v-else-if="sortState === 'asc'" version="1.1" xmlns="http://www.w3.org/2000/svg" height="100%" viewBox="0 0 24 24">
+                  <path fill="currentColor" d="M7 14l5-5 5 5z" />
+                </svg>
+                <svg v-else version="1.1" xmlns="http://www.w3.org/2000/svg" height="100%" viewBox="0 0 24 24">
+                  <path fill="currentColor" d="M7 10l5 5 5-5z" />
+                </svg>
+              </button>
+            </th>
             <th class="nobreak" style="width: 25%;">{{ $t('music_singer') }}</th>
             <th class="nobreak" style="width: 28%;">{{ $t('music_album') }}</th>
             <th class="nobreak" style="width: 10%;">{{ $t('music_time') }}</th>
@@ -22,18 +48,19 @@
       </table>
     </div>
     <div v-show="list.length" ref="dom_listContent" :class="$style.content">
+      <letter-index v-if="sortState !== 'none'" :list="list" :sort-state="sortState" @scroll-to="handleScrollToIndex" />
       <base-virtualized-list
         v-if="actionButtonsVisible" ref="listRef" v-slot="{ item, index }" :list="list" key-name="id"
         :item-height="listItemHeight" container-class="scroll" content-class="list"
         @scroll="saveListPosition" @contextmenu.capture="handleListRightClick"
       >
         <div
-          class="list-item" :class="[{ [$style.active]: playerInfo.isPlayList && playerInfo.playIndex === index }, { selected: selectedIndex == index || rightClickSelectedIndex == index }, { active: selectedList.includes(item) }, { disabled: !assertApiSupport(item.source) }]"
+          class="list-item" :class="[{ [$style.active]: playerInfo.isPlayList && (sortState === 'none' ? playerInfo.playIndex === index : sortedPlayIndex === index) }, { selected: selectedIndex == index || rightClickSelectedIndex == index }, { active: selectedList.includes(item) }, { disabled: !assertApiSupport(item.source) }]"
           @click="handleListItemClick($event, index)" @contextmenu="handleListItemRightClick($event, index)"
         >
           <div class="list-item-cell no-select" :class="$style.num" style="flex: 0 0 5%;">
             <transition name="play-active">
-              <div v-if="playerInfo.isPlayList && playerInfo.playIndex === index" :class="$style.playIcon">
+              <div v-if="playerInfo.isPlayList && (sortState === 'none' ? playerInfo.playIndex === index : sortedPlayIndex === index)" :class="$style.playIcon">
                 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xlink="http://www.w3.org/1999/xlink" height="50%" viewBox="0 0 512 512" space="preserve">
                   <use xlink:href="#icon-play-outline" />
                 </svg>
@@ -60,12 +87,12 @@
       >
         <div
           class="list-item"
-          :class="[{ [$style.active]: playerInfo.isPlayList && playerInfo.playIndex === index }, { selected: selectedIndex == index || rightClickSelectedIndex == index }, { active: selectedList.includes(item) }, { disabled: !assertApiSupport(item.source) }]"
+          :class="[{ [$style.active]: playerInfo.isPlayList && (sortState === 'none' ? playerInfo.playIndex === index : sortedPlayIndex === index) }, { selected: selectedIndex == index || rightClickSelectedIndex == index }, { active: selectedList.includes(item) }, { disabled: !assertApiSupport(item.source) }]"
           @click="handleListItemClick($event, index)" @contextmenu="handleListItemRightClick($event, index)"
         >
           <div class="list-item-cell no-select" :class="$style.num" style="flex: 0 0 5%;">
             <transition name="play-active">
-              <div v-if="playerInfo.isPlayList && playerInfo.playIndex === index" :class="$style.playIcon">
+              <div v-if="playerInfo.isPlayList && (sortState === 'none' ? playerInfo.playIndex === index : sortedPlayIndex === index)" :class="$style.playIcon">
                 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xlink="http://www.w3.org/1999/xlink" height="50%" viewBox="0 0 512 512" space="preserve">
                   <use xlink:href="#icon-play-outline" />
                 </svg>
@@ -109,6 +136,7 @@ import { assertApiSupport } from '@renderer/store/utils'
 import SearchList from './components/SearchList.vue'
 import MusicSortModal from './components/MusicSortModal.vue'
 import MusicToggleModal from './components/MusicToggleModal.vue'
+import LetterIndex from './components/LetterIndex.vue'
 import useListInfo from './useListInfo'
 import useList from './useList'
 import useMenu from './useMenu'
@@ -120,6 +148,7 @@ import useMusicActions from './useMusicActions'
 import useSearch from './useSearch'
 import useListScroll from './useListScroll'
 import useMusicToggle from './useMusicToggle'
+import useNameSort from './useNameSort'
 import { appSetting } from '@renderer/store/setting'
 export default {
   name: 'MusicList',
@@ -127,6 +156,7 @@ export default {
     SearchList,
     MusicSortModal,
     MusicToggleModal,
+    LetterIndex,
   },
   props: {
     listId: {
@@ -252,6 +282,12 @@ export default {
 
     const { saveListPosition, restoreScroll } = useListScroll({ props, listRef, list, handleRestoreScroll })
 
+    const {
+      sortState,
+      toggleSort,
+      sortedPlayIndex,
+    } = useNameSort({ list, listRef })
+
 
     const handleListItemClick = (event, index) => {
       if (rightClickSelectedIndex.value > -1) return
@@ -299,6 +335,11 @@ export default {
     const scrollToTop = () => {
       listRef.value.scrollTo(0, true)
     }
+    const handleScrollToIndex = (index) => {
+      if (listRef.value) {
+        listRef.value.scrollToIndex(index, 0, true)
+      }
+    }
 
     return {
       listItemHeight,
@@ -312,6 +353,7 @@ export default {
       dom_listContent,
       listRef,
       excludeListIds,
+      handleScrollToIndex,
 
       menus,
       isShowItemMenu,
@@ -354,6 +396,10 @@ export default {
       isShowMusicToggleModal,
       selectedToggleMusicInfo,
       toggleSource,
+
+      sortState,
+      toggleSort,
+      sortedPlayIndex,
     }
   },
 }
@@ -412,6 +458,7 @@ export default {
   display: flex;
   flex-flow: column nowrap;
   flex: auto;
+  position: relative;
 }
 
 .noItem {
@@ -425,6 +472,29 @@ export default {
   p {
     font-size: 24px;
     color: var(--color-font-label);
+  }
+}
+
+.sortBtn {
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  opacity: 0.5;
+  transition: opacity 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &.active {
+    opacity: 1;
+    color: var(--color-primary);
   }
 }
 

--- a/src/renderer/views/List/MusicList/useLetterIndex.js
+++ b/src/renderer/views/List/MusicList/useLetterIndex.js
@@ -1,0 +1,44 @@
+const pinyinData = require('@common/utils/pinyin/pinyin.json')
+
+const RE_LETTER = /[a-zA-Z]/
+const RE_CHINESE = /[\u4e00-\u9fa5]/
+
+const getPinyinInitial = (char) => {
+  const pinyin = pinyinData[char]
+  return pinyin?.[0]?.[0]?.toUpperCase() || char.toUpperCase()
+}
+
+export const getFirstLetter = (str) => {
+  if (!str) return '#'
+  const firstChar = str[0]
+
+  if (RE_LETTER.test(firstChar)) return firstChar.toUpperCase()
+  if (RE_CHINESE.test(firstChar)) {
+    const initial = getPinyinInitial(firstChar)
+    return RE_LETTER.test(initial) ? initial : '#'
+  }
+  return '#'
+}
+
+export const groupByFirstLetter = (list) => {
+  const groups = {}
+
+  for (let i = 65; i <= 90; i++) {
+    groups[String.fromCharCode(i)] = []
+  }
+  groups['#'] = []
+
+  list.forEach((item, index) => {
+    const letter = getFirstLetter(item.name)
+    ;(groups[letter] || groups['#']).push(index)
+  })
+
+  const letters = []
+  for (let i = 65; i <= 90; i++) {
+    const letter = String.fromCharCode(i)
+    if (groups[letter].length) letters.push(letter)
+  }
+  if (groups['#'].length) letters.push('#')
+
+  return { letters, groups }
+}

--- a/src/renderer/views/List/MusicList/useNameSort.js
+++ b/src/renderer/views/List/MusicList/useNameSort.js
@@ -1,0 +1,71 @@
+import { ref, computed, watch } from '@common/utils/vueTools'
+import { playMusicInfo } from '@renderer/store/player/state'
+import { getFirstLetter } from './useLetterIndex'
+
+export default ({ list, listRef }) => {
+  const sortState = ref('none')
+  const originalOrder = ref([])
+
+  const toggleSort = () => {
+    if (sortState.value === 'none') {
+      originalOrder.value = list.value.map(item => item.id)
+      sortList('asc')
+      sortState.value = 'asc'
+    } else if (sortState.value === 'asc') {
+      sortList('desc')
+      sortState.value = 'desc'
+    } else {
+      restoreOrder()
+      sortState.value = 'none'
+    }
+  }
+
+  const sortList = (direction) => {
+    const sorted = [...list.value].sort((a, b) => {
+      const letterA = getFirstLetter(a.name)
+      const letterB = getFirstLetter(b.name)
+
+      if (letterA === '#' && letterB !== '#') return 1
+      if (letterB === '#' && letterA !== '#') return -1
+
+      const nameA = (a.name || '').toLowerCase()
+      const nameB = (b.name || '').toLowerCase()
+      return direction === 'asc'
+        ? nameA.localeCompare(nameB, 'zh-CN')
+        : nameB.localeCompare(nameA, 'zh-CN')
+    })
+    list.value = sorted
+  }
+
+  const restoreOrder = () => {
+    if (!originalOrder.value.length) return
+    const orderMap = new Map(originalOrder.value.map((id, index) => [id, index]))
+    list.value = [...list.value].sort((a, b) => {
+      return (orderMap.get(a.id) ?? Infinity) - (orderMap.get(b.id) ?? Infinity)
+    })
+    originalOrder.value = []
+  }
+
+  const resetSort = () => {
+    sortState.value = 'none'
+    originalOrder.value = []
+  }
+
+  const sortedPlayIndex = computed(() => {
+    if (sortState.value === 'none' || !playMusicInfo.musicInfo) return -1
+    return list.value.findIndex(item => item.id === playMusicInfo.musicInfo.id)
+  })
+
+  watch(() => list.value.length, () => {
+    if (sortState.value !== 'none' && originalOrder.value.length !== list.value.length) {
+      resetSort()
+    }
+  })
+
+  return {
+    sortState,
+    toggleSort,
+    resetSort,
+    sortedPlayIndex,
+  }
+}

--- a/src/renderer/views/List/MusicList/usePlay.js
+++ b/src/renderer/views/List/MusicList/usePlay.js
@@ -1,12 +1,15 @@
 import { addTempPlayList } from '@renderer/store/player/action'
-import { playList } from '@renderer/core/player'
+import { playListById } from '@renderer/core/player/action'
 
 export default ({ props, selectedList, list, removeAllSelect }) => {
   let clickTime = 0
   let clickIndex = -1
 
   const handlePlayMusic = (index) => {
-    playList(props.listId, index)
+    const musicInfo = list.value[index]
+    if (musicInfo) {
+      playListById(props.listId, musicInfo.id)
+    }
   }
 
   const handlePlayMusicLater = (index, single) => {


### PR DESCRIPTION
- 新增歌名列排序按钮，支持升序/降序/原始顺序切换
- 排序时显示右侧字母索引栏，点击可快速定位
- 中文歌曲名支持拼音首字母排序
- 数字/特殊字符开头的歌曲统一归类到 # 分组并置于最后
- 排序后播放、操作等功能正常工作