### PR TITLE
Quality: Add skipTaskbar option and Linux-specific handling for desktop lyric window

### DIFF
--- a/src/main/modules/desktopLyric/index.ts
+++ b/src/main/modules/desktopLyric/index.ts
@@ -1,0 +1,41 @@
+import { BrowserWindow } from 'electron'
+import path from 'path'
+import { isProd, isLinux } from '@common/utils'
+
+const isWayland = process.env.XDG_SESSION_TYPE === 'wayland'
+
+let win: BrowserWindow | null = null
+
+const createDesktopLyricWindow = () => {
+  if (win != null) return
+
+  win = new BrowserWindow({
+    width: 800,
+    height: 100,
+    frame: false,
+    transparent: true,
+    alwaysOnTop: true,
+    skipTaskbar: true,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false
+    }
+  })
+
+  win.on('ready-to-show', () => {
+    if (!isWayland) win.setSkipTaskbar(true)
+  })
+
+  const url = isProd
+    ? `file://${path.join(__dirname, '../renderer-lyric/index.html')}`
+    : 'http://localhost:9081'
+  win.loadURL(url)
+
+  win.on('closed', () => {
+    win = null
+  })
+}
+
+export default () => {
+  createDesktopLyricWindow()
+}


### PR DESCRIPTION
## Description

The desktop lyric BrowserWindow was not properly hiding from the taskbar after the Electron 13->17 upgrade. This is due to changes in how Linux (especially Wayland) handles the skipTaskbar API. We need to explicitly set skipTaskbar: true in the constructor and call setSkipTaskbar(true) after ready-to-show. Add detection for Wayland session to avoid errors on platforms where the API is unavailable.

## Changes

- `src/main/modules/desktopLyric/index.ts` (new)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Code follows the style guidelines of this project
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Corresponding changes to documentation made (if applicable)

**Severity**: `high`


Closes #919