### PR TITLE
优化随机播放重新混洗交互

### DIFF
--- a/build-config/tests/play-mode-random.test.mjs
+++ b/build-config/tests/play-mode-random.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+
+import { resolvePlayModeSelection } from '../../src/renderer/core/player/playMode.mjs'
+
+const run = (name, fn) => {
+  try {
+    fn()
+    console.log(`PASS ${name}`)
+  } catch (err) {
+    console.error(`FAIL ${name}`)
+    throw err
+  }
+}
+
+run('switching to random requests random queue reset', () => {
+  assert.deepEqual(resolvePlayModeSelection('listLoop', 'random'), {
+    nextMode: 'random',
+    shouldResetRandomQueue: true,
+  })
+})
+
+run('clicking random again keeps mode and requests random queue reset', () => {
+  assert.deepEqual(resolvePlayModeSelection('random', 'random'), {
+    nextMode: 'random',
+    shouldResetRandomQueue: true,
+  })
+})
+
+run('non-random repeated click does nothing special', () => {
+  assert.deepEqual(resolvePlayModeSelection('listLoop', 'listLoop'), {
+    nextMode: 'listLoop',
+    shouldResetRandomQueue: false,
+  })
+})

--- a/src/renderer/components/common/TogglePlayModeBtn.vue
+++ b/src/renderer/components/common/TogglePlayModeBtn.vue
@@ -74,7 +74,7 @@
 </template>
 
 <script setup>
-import { ref } from '@common/utils/vueTools'
+import { nextTick, ref } from '@common/utils/vueTools'
 // import useNextTogglePlay from '@renderer/utils/compositions/useNextTogglePlay'
 // import useToggleDesktopLyric from '@renderer/utils/compositions/useToggleDesktopLyric'
 // import { musicInfo, playMusicInfo } from '@renderer/store/player/state'
@@ -90,7 +90,9 @@ const {
 
 const toggleMode = (mode) => {
   btn_ref.value.hide()
-  toggleNextPlayMode(mode)
+  void nextTick(() => {
+    toggleNextPlayMode(mode)
+  })
 }
 
 </script>

--- a/src/renderer/core/player/action.ts
+++ b/src/renderer/core/player/action.ts
@@ -282,6 +282,15 @@ export const resetRandomNextMusicInfo = () => {
   }
 }
 
+export const resetRandomPlayQueue = () => {
+  resetRandomNextMusicInfo()
+  clearPlayedList()
+
+  if (!playMusicInfo.musicInfo || playMusicInfo.isTempPlay) return
+
+  addPlayedList({ ...(playMusicInfo as LX.Player.PlayMusicInfo) })
+}
+
 export const getNextPlayMusicInfo = async(): Promise<LX.Player.PlayMusicInfo | null> => {
   if (tempPlayList.length) { // 如果稍后播放列表存在歌曲则直接播放改列表的歌曲
     const playMusicInfo = tempPlayList[0]

--- a/src/renderer/core/player/playMode.mjs
+++ b/src/renderer/core/player/playMode.mjs
@@ -1,0 +1,6 @@
+export const resolvePlayModeSelection = (currentMode, selectedMode) => {
+  return {
+    nextMode: selectedMode,
+    shouldResetRandomQueue: selectedMode === 'random',
+  }
+}

--- a/src/renderer/utils/compositions/useNextTogglePlay.ts
+++ b/src/renderer/utils/compositions/useNextTogglePlay.ts
@@ -3,6 +3,8 @@ import {
   computed,
 } from '@common/utils/vueTools'
 import { useI18n } from '@renderer/plugins/i18n'
+import { resetRandomPlayQueue } from '@renderer/core/player'
+import { resolvePlayModeSelection } from '@renderer/core/player/playMode.mjs'
 
 // const playNextModes = [
 //   'listLoop',
@@ -25,10 +27,9 @@ export default () => {
   })
 
   const toggleNextPlayMode = (mode: LX.AppSetting['player.togglePlayMethod']) => {
-    if (mode == appSetting['player.togglePlayMethod']) return
-    // let index = playNextModes.indexOf(appSetting['player.togglePlayMethod'])
-    // if (++index >= playNextModes.length) index = 0
-    setTogglePlayMode(mode)
+    const { nextMode, shouldResetRandomQueue } = resolvePlayModeSelection(appSetting['player.togglePlayMethod'], mode)
+    if (nextMode != appSetting['player.togglePlayMethod']) setTogglePlayMode(nextMode)
+    if (shouldResetRandomQueue) resetRandomPlayQueue()
   }
 
   return {


### PR DESCRIPTION
 -  Closes #2787

  ## 概要

  - 优化随机播放交互：点击随机播放按钮时触发重新混洗
  - 从其他模式切换到 `random` 时，会立即重置当前随机链路
  - 当前已经处于 `random` 模式时，再次点击 `random`，不会切换模式，但会重新随机当前列表
  - 修复播放模式弹层点击后关闭与状态更新同帧触发导致的运行时报错

  ## 具体改动

  - 新增播放模式选择逻辑模块 `src/renderer/core/player/playMode.mjs`
  - 新增随机播放链路重置入口
  - 调整播放模式按钮点击逻辑，使 `random` 按钮支持重复点击后重新混洗
  - 调整播放模式弹层关闭与状态更新时序，避免 Vue 运行时节点插入异常
  - 新增测试脚本 `build-config/tests/play-mode-random.test.mjs`

  ## 功能说明

  - 点击 `random` 按钮时始终触发随机播放链路重置
  - 若当前模式不是 `random`，则切换到 `random` 并重置随机顺序
  - 若当前模式已经是 `random`，则保持模式不变，仅重新随机当前列表
  - 自动播放下一首、普通手动上一首/下一首逻辑不额外触发重新混洗
  - 临时队列 `tempPlayList` 的优先播放逻辑保持不变

  ## 验证方式

  - `node build-config/tests/play-mode-random.test.mjs`
  - `node build-config/tests/player-queue.test.mjs`
  - `npm run lint`
  - `npm run build:renderer`
  
  ## 截图展示 

<img width="1089" height="691" alt="2" src="https://github.com/user-attachments/assets/86668364-f3fe-44ad-88f2-121badc26677" />

