### PR TITLE
修复列表文字区域右键菜单

### DIFF
--- a/build-config/tests/list-context-menu.test.mjs
+++ b/build-config/tests/list-context-menu.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+
+import { shouldCopyListTextOnContextMenu } from '../../src/renderer/utils/listContextMenu.mjs'
+
+const run = (name, fn) => {
+  try {
+    fn()
+    console.log(`PASS ${name}`)
+  } catch (error) {
+    console.error(`FAIL ${name}`)
+    throw error
+  }
+}
+
+run('does not hijack row menu when right-clicking selectable text without an active selection', () => {
+  assert.equal(shouldCopyListTextOnContextMenu({
+    isSelectTextTarget: true,
+    selectionText: '',
+  }), false)
+})
+
+run('keeps text copy behavior when right-clicking selected text', () => {
+  assert.equal(shouldCopyListTextOnContextMenu({
+    isSelectTextTarget: true,
+    selectionText: 'Song Name',
+  }), true)
+})
+
+run('ignores non-select targets', () => {
+  assert.equal(shouldCopyListTextOnContextMenu({
+    isSelectTextTarget: false,
+    selectionText: 'Song Name',
+  }), false)
+})

--- a/src/renderer/components/material/OnlineList/index.vue
+++ b/src/renderer/components/material/OnlineList/index.vue
@@ -102,6 +102,7 @@
 import { clipboardWriteText } from '@common/utils/electron'
 import { assertApiSupport } from '@renderer/store/utils'
 import { ref } from '@common/utils/vueTools'
+import { shouldCopyListTextOnContextMenu, formatListSelectionText } from '@renderer/utils/listContextMenu.mjs'
 import useList from './useList'
 import useMenu from './useMenu'
 import usePlay from './usePlay'
@@ -218,14 +219,17 @@ export default {
       menuClick(action, index)
     }
     const handleListRightClick = (event) => {
-      if (!event.target.classList.contains('select')) return
+      const selectionText = window.getSelection().toString()
+      if (!shouldCopyListTextOnContextMenu({
+        isSelectTextTarget: event.target.classList.contains('select'),
+        selectionText,
+      })) return
       event.stopImmediatePropagation()
       let classList = dom_listContent.value.classList
       classList.add('copying')
       window.requestAnimationFrame(() => {
-        let str = window.getSelection().toString()
         classList.remove('copying')
-        str = str.split(/\n\n/).map(s => s.replace(/\n/g, '  ')).join('\n').trim()
+        let str = formatListSelectionText(window.getSelection().toString())
         if (!str.length) return
         clipboardWriteText(str)
       })

--- a/src/renderer/utils/listContextMenu.mjs
+++ b/src/renderer/utils/listContextMenu.mjs
@@ -1,0 +1,14 @@
+export const shouldCopyListTextOnContextMenu = ({
+  isSelectTextTarget,
+  selectionText,
+}) => {
+  return isSelectTextTarget && !!selectionText.trim()
+}
+
+export const formatListSelectionText = (selectionText) => {
+  return selectionText
+    .split(/\n\n/)
+    .map(text => text.replace(/\n/g, '  '))
+    .join('\n')
+    .trim()
+}

--- a/src/renderer/views/List/MusicList/index.vue
+++ b/src/renderer/views/List/MusicList/index.vue
@@ -106,6 +106,7 @@
 <script>
 import { clipboardWriteText } from '@common/utils/electron'
 import { assertApiSupport } from '@renderer/store/utils'
+import { shouldCopyListTextOnContextMenu, formatListSelectionText } from '@renderer/utils/listContextMenu.mjs'
 import SearchList from './components/SearchList.vue'
 import MusicSortModal from './components/MusicSortModal.vue'
 import MusicToggleModal from './components/MusicToggleModal.vue'
@@ -268,14 +269,17 @@ export default {
       menuClick(action, index)
     }
     const handleListRightClick = (event) => {
-      if (!event.target.classList.contains('select')) return
+      const selectionText = window.getSelection().toString()
+      if (!shouldCopyListTextOnContextMenu({
+        isSelectTextTarget: event.target.classList.contains('select'),
+        selectionText,
+      })) return
       event.stopImmediatePropagation()
       let classList = dom_listContent.value.classList
       classList.add('copying')
       window.requestAnimationFrame(() => {
-        let str = window.getSelection().toString()
         classList.remove('copying')
-        str = str.split(/\n\n/).map(s => s.replace(/\n/g, '  ')).join('\n').trim()
+        let str = formatListSelectionText(window.getSelection().toString())
         if (!str.length) return
         clipboardWriteText(str)
       })


### PR DESCRIPTION
  ## 概要
  在使用过程中发现，列表中的歌曲名、歌手、专辑等文字区域无法右键弹出歌曲菜单，只能在文字之外的区域右键。
  我不确定这是否是有意为之，但从交互预期来看，左键选中与右键菜单应当彼此独立，文字区域也应支持正常右键操作。

  - 修复列表中右键歌曲名、歌手、专辑等文字时无法弹出右键菜单的问题
  - 调整列表文字区域的右键事件处理逻辑，避免在普通右键场景下拦截歌曲项菜单
  - 保留文本复制能力，仅在右键的是已选中文本时才走复制分支

  ## 问题原因

  - 列表容器在 @contextmenu.capture 阶段会优先拦截 .select 文本上的右键事件
  - 之前只要命中可选中文本，就会直接阻止事件继续传递，导致事件无法到达歌曲行上的右键菜单逻辑
  - 因此在歌曲名、歌手、专辑等文字区域右键时，不会弹出歌曲右键菜单

  ## 具体改动

  - 为列表右键行为抽出共享判断逻辑
  - 仅当右键目标为可选中文本且当前存在有效选区时，才执行复制文本处理
  - 普通右键文字时继续让事件传递到歌曲行，正常弹出右键菜单
  - 同步修复本地歌单列表和在线列表的同类问题
  - 新增对应测试，覆盖文字右键与文本复制两类行为

  ## 影响范围

  - src/renderer/views/List/MusicList/index.vue
  - src/renderer/components/material/OnlineList/index.vue
  - src/renderer/utils/listContextMenu.mjs
  - build-config/tests/list-context-menu.test.mjs

  ## 验证方式

  - node build-config/tests/list-context-menu.test.mjs
  - node build-config/tests/player-queue.test.mjs
  - npm run lint
  - npm run build:renderer