### PR TITLE
Windows环境，歌曲文件名中存在#特殊字符时无法正常播放

### DIFF
--- a/src/common/utils/common.ts
+++ b/src/common/utils/common.ts
@@ -1,5 +1,6 @@
 // 非业务工具方法
 
+import { pathToFileURL } from 'url'
 /**
  * 获取两个数之间的随机整数，大于等于min，小于max
  * @param {*} min
@@ -188,7 +189,7 @@ export const sortInsert = <T>(arr: Array<{ num: number, data: T }>, data: { num:
 }
 
 export const encodePath = (path: string) => {
-  return encodeURI(path.replaceAll('\\', '/'))
+  return pathToFileURL(path).href
 }
 
 


### PR DESCRIPTION
调整解析url函数，从encodeURI改为pathToFileURL
验证：歌曲文件名，存在#特殊字符，可以正常导入，但播放时会提示source not found，修改文件名后可正常播放。