### PR TITLE
Win文件名中存在#特殊字符时无法正常播放

### DIFF
--- a/src/common/utils/common.ts
+++ b/src/common/utils/common.ts
@@ -1,5 +1,6 @@
 // 非业务工具方法
 
+import { pathToFileURL } from 'url'
 /**
  * 获取两个数之间的随机整数，大于等于min，小于max
  * @param {*} min
@@ -188,7 +189,7 @@ export const sortInsert = <T>(arr: Array<{ num: number, data: T }>, data: { num:
 }
 
 export const encodePath = (path: string) => {
-  return encodeURI(path.replaceAll('\\', '/'))
+  return pathToFileURL(path).href
 }
 
 


### PR DESCRIPTION
[Bug]: Windows环境，歌曲文件名包含#特殊字符时，无法正常播放
 #2861  
原因：特殊字符#在解析url时未正常转义，导致歌曲文件播放时实际找不到
方案：调整获取url的方法，从encodeURI改为pathToFileURL
影响：预计无其他不良影响