### PR TITLE
feat: Open API 扩展 — 多音源搜索 + 歌单管理 + 播放控制 + AI 集成

### DIFF
--- a/lx-music-api-skill/SKILL.md
+++ b/lx-music-api-skill/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: lx-music-api
+description: Control LX Music Desktop via its Open API — search, play, manage playlists
+---
+
+# LX Music Open API — Complete Reference
+
+You are an AI agent controlling LX Music Desktop (`http://127.0.0.1:23330`). All endpoints return JSON unless noted.
+
+**Never mention internal tool names to the user** (e.g. `batch_add.js`, `node -e`, `curl`, endpoint paths). Just say what you can do: "I'll create a playlist", "Let me search for that", etc.
+
+## Quick Decision Guide
+
+| User wants | Method |
+|------------|--------|
+| Play/pause/skip/volume/seek | Direct `curl` GET → done |
+| Search songs | `node -e` one-liner (see Encoding Notes) |
+| Search → add to playlist | `batch_add.js` (built-in cover filter) |
+| Search with custom rules (only flac, only female, etc.) | Write temp script — max 5 concurrent, 100ms batch gap |
+| Sort/filter/reorder a playlist | `GET /list` → compute → `POST /overwrite` |
+| Play a specific song from playlist | `GET /list` → `POST /player/play` |
+| Check what's playing | `GET /status` or `GET /player/list` |
+| Delete songs/playlists | `POST /playlist/songs` or `/playlist/remove` |
+
+---
+
+## All Endpoints
+
+### Player Control (original)
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/play` | GET | Resume playback |
+| `/pause` | GET | Pause |
+| `/skip-next` | GET | Next track |
+| `/skip-prev` | GET | Previous track |
+| `/seek?offset=30.5` | GET | Seek to position (seconds) |
+| `/volume?volume=80` | GET | Set volume 1-100 |
+| `/mute?mute=true` | GET | Mute/unmute |
+| `/collect` | GET | Favorite current song |
+| `/uncollect` | GET | Unfavorite current song |
+
+### Player Status (original)
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /status?filter=status,name,singer,duration,progress` | Current song info (JSON). Default filter: `status,name,singer,albumName,lyricLineText,duration,progress,playbackRate`. Available fields: `status,name,singer,albumName,duration,progress,playbackRate,picUrl,lyricLineText,lyricLineAllText,lyric,tlyric,rlyric,lxlyric,collect,volume,mute` |
+| `GET /lyric` | Current LRC lyric (plain text) |
+| `GET /lyric-all` | All lyric types `{lyric,tlyric,rlyric,lxlyric}` |
+| `GET /subscribe-player-status?filter=...` | SSE stream — real-time status push |
+
+### Player Control (new)
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `POST /player/play` | POST | Play specific song from playlist. Body: `{"listId":"...","musicInfo":{...}}`. `musicInfo` must be the full raw object from search or `/playlist/list` — never trim it. Missing `qualitys`/`_qualitys` fields = song never starts. |
+| `GET /player/list` | GET | Current play queue. Returns `{listId, currentIndex (0-based), count, list: MusicInfo[]}` |
+
+### Search (new)
+
+```
+GET /search?keyword={keyword}&source={source}&dedup={dedup}&matchSinger={singer}&minQuality={quality}&page={page}&limit={limit}&order={order}
+```
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `keyword` | **required** | Search text. Must be URL-encoded by caller (see Encoding Notes). |
+| `source` | all | `kw` `kg` `mg` `tx` `wy` |
+| `page` | 1 | Page |
+| `limit` | 20 | Per page |
+| `dedup` | false | Remove duplicates, keep best quality |
+| `matchSinger` | — | Prioritize singer match. See Singer Match Levels below. |
+| `minQuality` | — | Filter: `128k` `320k` `flac` `flac24bit`. See Quality Ranking below. |
+| `order` | settings | Comma-separated source priority. Omit to use user's default. |
+
+Response: `{ list: MusicInfo[], total, allPage, page, limit }`
+
+Each `MusicInfo`: `{ id, name, singer, source, interval, meta: { songId, albumName, qualitys[], _qualitys{} } }`
+
+### Playlist Management (new)
+
+| Endpoint | Method | Body | Returns |
+|----------|--------|------|---------|
+| `GET /playlists` | GET | — | `[{id, name, source, ...}]` all user playlists |
+| `POST /playlist/create` | POST | `{"name":"..."}` | `{"id":"userlist_xxx","name":"..."}` |
+| `POST /playlist/add` | POST | `{"listId":"..","musicInfos":[...]}` | `{"count":N}` |
+| `GET /playlist/list?listId=xxx` | GET | — | `{"listId":"..","songs":[...]}` |
+| `POST /playlist/overwrite` | POST | `{"listId":"..","musicInfos":[...]}` | `{"count":N}` — replaces entire playlist |
+| `POST /playlist/remove` | POST | `{"ids":["userlist_xxx"]}` | `{"removed":N}` |
+| `POST /playlist/songs` | POST | `{"listId":"..","ids":["kw_123"]}` | `{"removed":N}` |
+
+**Critical rules:**
+- `musicInfos` in `/add`, `/overwrite`, and `/player/play` must be **complete** `MusicInfo` objects from search or `/list` — including `meta.qualitys[]` and `meta._qualitys{}` fields. Never manually construct or trim them. Missing quality info causes silent play failure (song appears in UI but never starts).
+- `POST /playlist/remove` takes playlist IDs (e.g. `userlist_*`).
+- `POST /playlist/songs` takes song IDs within a playlist (e.g. `kw_xxx`, `kg_xxx`).
+
+---
+
+## Common Workflows
+
+### 1. Add songs to a playlist
+```
+GET /playlists                      → find target playlist ID
+GET /search?keyword=...&dedup=true  → for each song
+POST /playlist/add                  → bulk add
+```
+
+### 2. Play a specific song from a playlist
+```
+GET /playlist/list?listId=xxx       → get songs
+POST /player/play                   → {listId, musicInfo: songs[0]}
+```
+
+### 3. Check what's playing / queue
+```
+GET /player/list    → {listId, currentIndex, count, list}
+```
+`list[currentIndex]` is current song. `list.slice(currentIndex+1)` is upcoming.
+
+### 4. Batch import many songs
+```bash
+node batch_add.js "歌单名" "周杰伦 - 夜曲, 光良 童话, 黄昏"
+node batch_add.js --all "歌单名" "..."   # include covers/DJ/instrumental
+```
+Input formats: `songname` / `singer - songname` / `singer songname`. Outputs JSON.
+
+### 5. Reorder / filter / sort a playlist
+```
+GET /playlist/list?listId=xxx    → get all songs
+(compute sort/filter client-side)
+POST /playlist/overwrite         → replace entire list
+```
+
+### 6. Clean up
+```
+POST /playlist/songs  {listId, ids}   → remove specific songs
+POST /playlist/remove {ids}          → delete playlist(s)
+```
+
+---
+
+## Encoding Notes
+
+- **POST body**: The server auto-detects GBK encoding (Windows terminal curl). If you see garbled playlist names, the server handles it. Send UTF-8 when possible.
+- **Search with Chinese**: One command, just replace the keyword. Never use `curl --data-urlencode` — it's the root cause of garbled results on Windows.
+  ```bash
+  node -e "const kw=encodeURIComponent('关键词');require('http').get('http://127.0.0.1:23330/search?keyword='+kw+'&dedup=true&limit=10',r=>{let d='';r.on('data',c=>d+=c);r.on('end',()=>JSON.parse(d).list.forEach(s=>console.log(s.name,s.singer)))})"
+  ```
+- **Playback timing**: After `POST /player/play`, wait **3 seconds** before checking `/status`. Shorter waits will see transient `"error"` / `"stoped"` during loading — this is normal. If `status != "playing"` after 3 seconds, play truly failed.
+- **Multiple searches (IMPORTANT)**: Never send more than **5 concurrent requests**. Batch them in groups of 5 with 100ms between batches. More than 5 concurrent connections risk `ECONNRESET` / socket hang up. If any request fails with `ECONNRESET`, retry it once after 200ms — the retry almost always succeeds.
+
+## Quality Ranking
+`flac24bit > flac > 320k > 128k > none`
+
+## Singer Match Levels
+- `exact` (score 100): Original artist
+- `partial` (score 50): Collaboration/feature
+- `none` (score 0): Cover version

--- a/lx-music-api-skill/batch_add.js
+++ b/lx-music-api-skill/batch_add.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// batch_add.js — 批量搜索并添加歌曲到 LX Music 歌单
+// 用法: node batch_add.js "歌单名" "歌曲1, 歌曲2, ..."
+//       node batch_add.js "歌单名" "周杰伦 - 夜曲, 光良 童话, 黄昏"
+//       node batch_add.js --all "歌单名" "歌曲1, 歌曲2"   ← 不过滤翻唱/纯音乐
+
+const http = require('http');
+const API = 'http://127.0.0.1:23330';
+const MAX_PARALLEL = 5;
+const ADD_BATCH = 30;
+const TIMEOUT = 10000;
+
+const badPatterns = /Live|DJ|R&B版|cover|翻唱|新版|合唱|空灵鼓|练习曲|Remix|Mix|片段|现场|串烧|DJ版|慢摇|演唱会|伴奏|纯音乐/;
+
+// ========= 工具 =========
+
+function request(method, path, body) {
+  return new Promise((resolve, reject) => {
+    const u = new URL(path, API);
+    const opts = { hostname: u.hostname, port: u.port, path: u.pathname + u.search, method, timeout: TIMEOUT,
+      headers: { 'Content-Type': 'application/json' } };
+    if (body) {
+      const b = JSON.stringify(body);
+      opts.headers['Content-Length'] = Buffer.byteLength(b);
+    }
+    const req = http.request(opts, res => {
+      let d = ''; res.on('data', c => d += c);
+      res.on('end', () => { try { resolve(JSON.parse(d)) } catch(e) { resolve(d) } });
+    });
+    req.on('error', reject);
+    if (body) req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
+const get = url => request('GET', url);
+const post = (path, body) => request('POST', path, body);
+
+// ========= 解析输入 =========
+
+function parseSong(raw) {
+  // "周杰伦 - 夜曲" → { song: "夜曲", artist: "周杰伦" }
+  // "周杰伦 夜曲"  → { song: "夜曲", artist: "周杰伦" }
+  // "夜曲"         → { song: "夜曲", artist: null }
+  let s = raw.trim();
+  if (!s) return null;
+  // "singer - song"
+  const sep = s.match(/^(.+?)\s*[-–—]\s*(.+)$/);
+  if (sep) return { song: sep[2].trim(), artist: sep[1].trim(), includeAll: false };
+  // "singer song" — if two parts and second part looks like a song name
+  const parts = s.split(/\s+/);
+  if (parts.length === 2 && parts[1].length >= 2) return { song: parts[1], artist: parts[0], includeAll: false };
+  return { song: s, artist: null, includeAll: false };
+}
+
+// ========= 搜索 =========
+
+async function searchSong(song, artist, includeAll) {
+  const q = encodeURIComponent(song);
+  let path = `/search?keyword=${q}&dedup=true&limit=10`;
+  if (artist) path += `&matchSinger=${encodeURIComponent(artist)}`;
+  
+  const data = await get(path);
+  if (!data || !data.list || !data.list.length) return { song, found: false, reason: 'no_results' };
+  
+  let good = includeAll ? data.list : data.list.filter(i => !badPatterns.test(i.name) && !badPatterns.test(i.singer));
+  if (!good.length) good = data.list;
+  
+  const pick = good[0];
+  const matchLevel = pick._matchLevel || (artist ? 'unknown' : 'unspecified');
+  const issues = [];
+  if (artist && matchLevel !== 'exact') issues.push(`singer_${matchLevel}`);
+  
+  return { song, found: true, name: pick.name, singer: pick.singer, source: pick.source,
+    matchLevel, issues, musicInfo: pick };
+}
+
+async function parallelSearch(songs, concurrency) {
+  const results = [];
+  const queue = [...songs];
+  
+  async function worker() {
+    while (queue.length) {
+      const s = queue.shift();
+      if (!s) break;
+      try {
+        const r = await searchSong(s.song, s.artist, s.includeAll);
+        process.stderr.write(r.found ? '.' : 'x');
+        results.push(r);
+      } catch(e) {
+        process.stderr.write('E');
+        results.push({ song: s.song, found: false, reason: 'error', error: e.message });
+      }
+    }
+  }
+  
+  process.stderr.write(`搜索中 `);
+  await Promise.all(Array(Math.min(concurrency, songs.length)).fill(0).map(() => worker()));
+  process.stderr.write('\n');
+  return results;
+}
+
+async function incrementalAdd(playlistId, musicInfos, batchSize) {
+  let total = 0;
+  for (let i = 0; i < musicInfos.length; i += batchSize) {
+    const batch = musicInfos.slice(i, i + batchSize);
+    const r = await post('/playlist/add', { listId: playlistId, musicInfos: batch });
+    if (r && r.count) total += r.count;
+    process.stderr.write(`+${batch.length} `);
+  }
+  process.stderr.write('\n');
+  return total;
+}
+
+// ========= 主流程 =========
+
+(async () => {
+  let includeAll = false;
+  let plName = process.argv[2];
+  let rawStart = 3;
+  if (plName === '--all') { includeAll = true; plName = process.argv[3]; rawStart = 4; }
+  const raw = process.argv.slice(rawStart).join(' ');
+  if (!plName || !raw) {
+    console.error('用法: node batch_add.js [--all] "歌单名" "歌曲1, 歌曲2, ..."');
+    console.error('      --all  不过滤翻唱/Live/DJ/纯音乐');
+    process.exit(1);
+  }
+
+  // 解析歌曲列表
+  const parsed = raw
+    .split(/[，,\n]/)
+    .map(parseSong)
+    .filter(s => s);
+
+  if (!parsed.length) {
+    console.error('未解析到有效歌曲');
+    process.exit(1);
+  }
+
+  // 1. 创建歌单
+  process.stderr.write(`创建歌单 "${plName}"... `);
+  const pl = await post('/playlist/create', { name: plName });
+  if (!pl || !pl.id) { console.error('创建失败'); process.exit(1); }
+  process.stderr.write(`ID: ${pl.id}\n`);
+
+  // 2. 搜索
+  const results = await parallelSearch(parsed, MAX_PARALLEL);
+
+  // 3. 统计
+  const found = results.filter(r => r.found);
+  const failed = results.filter(r => !r.found);
+  const uncertain = found.filter(r => r.issues.length > 0);
+
+  // 4. 增量添加
+  process.stderr.write(`添加中 `);
+  const count = await incrementalAdd(pl.id, found.map(r => r.musicInfo), ADD_BATCH);
+
+  // 5. JSON 输出
+  console.log(JSON.stringify({
+    playlist: { id: pl.id, name: pl.name },
+    summary: { total: parsed.length, found: found.length, added: count, failed: failed.length, uncertain: uncertain.length },
+    failed: failed.map(r => ({ song: r.song, reason: r.reason })),
+    uncertain: uncertain.map(r => ({
+      song: r.song, picked: r.name, singer: r.singer, source: r.source,
+      matchLevel: r.matchLevel, issues: r.issues,
+    })),
+    found: found.map(r => ({ song: r.song, name: r.name, singer: r.singer, source: r.source, matchLevel: r.matchLevel })),
+  }, null, 2));
+})();

--- a/src/common/defaultSetting.ts
+++ b/src/common/defaultSetting.ts
@@ -148,6 +148,7 @@ const defaultSetting: LX.AppSetting = {
   'openAPI.enable': false,
   'openAPI.port': '23330',
   'openAPI.bindLan': false,
+  'openAPI.sourceOrder': 'kg,kw,mg,tx,wy',
 
   // 'theme.id': 'blue_plus',
   'theme.id': 'green',

--- a/src/common/rendererIpc.ts
+++ b/src/common/rendererIpc.ts
@@ -43,3 +43,20 @@ export const rendererOff = (name: string, listener: (...args: any[]) => any) => 
 export const rendererOffAll = (name: string) => {
   ipcRenderer.removeAllListeners(name)
 }
+
+/**
+ * 注册 renderer 端 handler，供 main 进程通过 webContents.ipc.invoke 调用
+ */
+export function rendererHandle(name: string, listener: (params?: any) => Promise<any> | any): void {
+  if (typeof (ipcRenderer as any).handle !== 'function') {
+    console.warn('ipcRenderer.handle not available, skipping:', name)
+    return
+  }
+  (ipcRenderer as any).handle(name, async (_event: any, params: any) => {
+    return listener(params)
+  })
+}
+
+export const rendererHandleRemove = (name: string) => {
+  (ipcRenderer as any).removeHandler(name)
+}

--- a/src/common/types/app_setting.d.ts
+++ b/src/common/types/app_setting.d.ts
@@ -682,6 +682,11 @@ declare global {
       'openAPI.bindLan': boolean
 
       /**
+       * 音源优先级，逗号分隔
+       */
+      'openAPI.sourceOrder': string
+
+      /**
        * 是否在离开搜索界面时自动清空搜索框
        */
       'odc.isAutoClearSearchInput': boolean

--- a/src/main/modules/openApi/index.ts
+++ b/src/main/modules/openApi/index.ts
@@ -1,19 +1,475 @@
 import http from 'node:http'
+import https from 'node:https'
+import crypto from 'node:crypto'
 import querystring from 'node:querystring'
 import type { Socket } from 'node:net'
 import { getAddress } from '@common/utils/nodejs'
-import { sendTaskbarButtonClick } from '@main/modules/winMain'
+import { sendTaskbarButtonClick, sendSearchRequest, sendPlayRequest, sendQueueRequest } from '@main/modules/winMain'
 
 const sendResponse = (res: http.ServerResponse, code = 200, msg: string | Record<any, unknown> = 'OK', contentType = 'text/plain; charset=utf-8') => {
   res.writeHead(code, {
     'Content-Type': contentType,
     'Access-Control-Allow-Origin': '*',
+    'Connection': 'close',
   })
   if (typeof msg === 'object') {
     res.end(JSON.stringify(msg))
   } else {
     res.end(msg)
   }
+}
+
+/**
+ * 解析 POST 请求体 (JSON)，自动检测编码
+ */
+const parseBody = (req: http.IncomingMessage): Promise<any> => new Promise((resolve, reject) => {
+  const chunks: Buffer[] = []
+  req.on('data', (chunk: Buffer) => chunks.push(chunk))
+  req.on('end', () => {
+    try {
+      const buf = Buffer.concat(chunks)
+      let raw = buf.toString('utf8')
+      // UTF-8 解码出现替换字符 → 可能是 GBK 编码
+      if (raw.includes('\ufffd')) {
+        try {
+          const iconv = require('iconv-lite')
+          const gbkTry: string = iconv.decode(buf, 'gbk')
+          if (!gbkTry.includes('\ufffd')) raw = gbkTry
+        } catch (_) {}
+      }
+      resolve(raw ? JSON.parse(raw) : {})
+    } catch (e) {
+      reject(new Error('Invalid JSON body'))
+    }
+  })
+  req.on('error', reject)
+})
+
+/**
+ * HTTP GET 请求封装（用于搜索音乐源 API），带超时 + gzip解压
+ */
+const httpGet = (url: string, timeout = 10000): Promise<any> => {
+  return doHttpGet(url, {}, timeout)
+}
+const httpGetWithHeaders = (url: string, extraHeaders: Record<string, string>, timeout = 10000): Promise<any> => {
+  return doHttpGet(url, extraHeaders, timeout)
+}
+const doHttpGet = (url: string, extraHeaders: Record<string, string>, timeout: number): Promise<any> => new Promise((resolve, reject) => {
+  const mod = url.startsWith('https') ? https : http
+  const req = mod.get(url, {
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      'Accept-Encoding': 'gzip, deflate',
+      ...extraHeaders,
+    },
+    timeout,
+  }, (resp) => {
+    const chunks: Buffer[] = []
+    let stream: any = resp
+    // 自动解压
+    const ce = resp.headers['content-encoding']
+    if (ce) {
+      const zlib = require('zlib')
+      if (ce.includes('gzip')) stream = resp.pipe(zlib.createGunzip())
+      else if (ce.includes('deflate')) stream = resp.pipe(zlib.createInflate())
+      else if (ce.includes('br')) stream = resp.pipe(zlib.createBrotliDecompress())
+    }
+    stream.on('data', (chunk: Buffer) => chunks.push(chunk))
+    stream.on('end', () => {
+      clearTimeout(timer)
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString()))
+      } catch (e) {
+        resolve(Buffer.concat(chunks).toString())
+      }
+    })
+    stream.on('error', (err: Error) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+  })
+  const timer = setTimeout(() => {
+    req.destroy()
+    reject(new Error('Request timeout'))
+  }, timeout)
+  req.on('error', (err) => {
+    clearTimeout(timer)
+    reject(err)
+  })
+})
+
+/**
+ * 搜索音乐 – 酷我 (kw)
+ * 返回与 SDK toNewMusicInfo 兼容的完整 MusicInfo 格式
+ */
+const searchKw = async(keyword: string, page: number, limit: number) => {
+  const url = `http://search.kuwo.cn/r.s?client=kt&all=${encodeURIComponent(keyword)}&pn=${page - 1}&rn=${limit}&uid=794762570&ver=kwplayer_ar_9.2.2.1&vipver=1&show_copyright_off=1&newver=1&ft=music&cluster=0&strategy=2012&encoding=utf8&rformat=json&vermerge=1&mobi=1&issubtitle=1`
+  const raw = await httpGet(url)
+  if (!raw || !raw.abslist) return { list: [], total: 0, allPage: 1, limit, page }
+
+  const mInfoRxp = /level:(\w+),bitrate:(\d+),format:(\w+),size:([\w.]+)/
+  const list = raw.abslist.map((info: any) => {
+    const songmid = info.MUSICRID ? info.MUSICRID.replace('MUSIC_', '') : ''
+    const intervalNum = parseInt(info.DURATION) || 0
+    const interval = intervalNum
+      ? String(Math.floor(intervalNum / 60)).padStart(2, '0') + ':' + String(Math.floor(intervalNum % 60)).padStart(2, '0')
+      : '00:00'
+
+    // 解析 N_MINFO 获取音质信息
+    const types: { type: string, size: string }[] = []
+    const _types: Record<string, { size: string }> = {}
+    if (info.N_MINFO) {
+      for (const part of info.N_MINFO.split(';')) {
+        const m = part.match(mInfoRxp)
+        if (!m) continue
+        let typeLabel: string
+        switch (m[2]) {
+          case '4000': typeLabel = 'flac24bit'; break
+          case '2000': typeLabel = 'flac'; break
+          case '320': typeLabel = '320k'; break
+          case '128': typeLabel = '128k'; break
+          default: continue
+        }
+        types.push({ type: typeLabel, size: m[4] })
+        _types[typeLabel] = { size: m[4].toUpperCase() }
+      }
+    }
+    types.reverse()
+
+    return {
+      id: `kw_${songmid}`,
+      name: info.SONGNAME || '',
+      singer: info.ARTIST || '',
+      source: 'kw' as const,
+      interval,
+      meta: {
+        songId: songmid,
+        albumName: info.ALBUM || '',
+        albumId: info.ALBUMID || '',
+        qualitys: types,
+        _qualitys: _types,
+        picUrl: null,
+        toggleMusicInfo: null,
+      },
+    }
+  })
+  const total = parseInt(raw.TOTAL) || list.length
+  return { list, total, allPage: Math.max(1, Math.ceil(total / limit)), limit, page }
+}
+
+/**
+ * 搜索音乐 – 酷狗 (kg)
+ * 返回与 SDK toNewMusicInfo 兼容的完整 MusicInfo 格式
+ */
+const searchKg = async(keyword: string, page: number, limit: number) => {
+  const url = `https://songsearch.kugou.com/song_search_v2?keyword=${encodeURIComponent(keyword)}&page=${page}&pagesize=${limit}&userid=0&clientver=&platform=WebFilter&filter=2&iscorrection=1&privilege_filter=0&area_code=1`
+  const raw = await httpGet(url)
+  if (!raw || raw.error_code !== 0 || !raw.data || !raw.data.lists) return { list: [], total: 0, allPage: 1, limit, page }
+
+  const sizeFormate = (size: number) => {
+    if (size < 1024) return size + 'B'
+    if (size < 1048576) return (size / 1024).toFixed(1) + 'K'
+    return (size / 1048576).toFixed(1) + 'M'
+  }
+
+  const filterItem = (item: any) => {
+    const songmid = item.Audioid || ''
+    const hash = item.FileHash || ''
+    const intervalNum = item.Duration || 0
+    const interval = intervalNum
+      ? String(Math.floor(intervalNum / 60)).padStart(2, '0') + ':' + String(Math.floor(intervalNum % 60)).padStart(2, '0')
+      : '00:00'
+
+    // 解析音质
+    const types: { type: string, size: string, hash: string }[] = []
+    const _types: Record<string, { size: string, hash: string }> = {}
+    if (item.FileSize !== 0) {
+      const sz = sizeFormate(item.FileSize)
+      types.push({ type: '128k', size: sz, hash: item.FileHash })
+      _types['128k'] = { size: sz, hash: item.FileHash }
+    }
+    if (item.HQFileSize !== 0) {
+      const sz = sizeFormate(item.HQFileSize)
+      types.push({ type: '320k', size: sz, hash: item.HQFileHash })
+      _types['320k'] = { size: sz, hash: item.HQFileHash }
+    }
+    if (item.SQFileSize !== 0) {
+      const sz = sizeFormate(item.SQFileSize)
+      types.push({ type: 'flac', size: sz, hash: item.SQFileHash })
+      _types.flac = { size: sz, hash: item.SQFileHash }
+    }
+    if (item.ResFileSize !== 0) {
+      const sz = sizeFormate(item.ResFileSize)
+      types.push({ type: 'flac24bit', size: sz, hash: item.ResFileHash })
+      _types.flac24bit = { size: sz, hash: item.ResFileHash }
+    }
+
+    const singer = item.Singers && item.Singers[0] ? item.Singers[0].name : ''
+
+    return {
+      id: `${songmid}_${hash}`,
+      name: item.SongName || '',
+      singer,
+      source: 'kg' as const,
+      interval,
+      meta: {
+        songId: songmid,
+        albumName: item.AlbumName || '',
+        albumId: item.AlbumID || '',
+        qualitys: types,
+        _qualitys: _types,
+        hash,
+        picUrl: null,
+        toggleMusicInfo: null,
+      },
+    }
+  }
+
+  // 处理歌曲组 (Grp)
+  const seen = new Set<string>()
+  const list: any[] = []
+  for (const item of raw.data.lists) {
+    const key = item.Audioid + item.FileHash
+    if (!seen.has(key)) {
+      seen.add(key)
+      list.push(filterItem(item))
+    }
+    if (item.Grp) {
+      for (const child of item.Grp) {
+        const cKey = child.Audioid + child.FileHash
+        if (!seen.has(cKey)) {
+          seen.add(cKey)
+          list.push(filterItem(child))
+        }
+      }
+    }
+  }
+
+  const total = raw.data.total || list.length
+  return { list, total, allPage: Math.max(1, Math.ceil(total / limit)), limit, page }
+}
+
+/**
+ * 搜索音乐 – 咪咕 (mg)
+ * 返回与 SDK toNewMusicInfo 兼容的完整 MusicInfo 格式
+ */
+const searchMg = async(keyword: string, page: number, limit: number) => {
+  const time = Date.now().toString()
+  const deviceId = '963B7AA0D21511ED807EE5846EC87D20'
+  const signatureMd5 = '6cdc72a439cef99a3418d2a78aa28c73'
+  const sign = crypto.createHash('md5').update(`${keyword}${signatureMd5}yyapp2d16148780a1dcc7408e06336b98cfd50${deviceId}${time}`).digest('hex')
+  const searchSwitch = '%7B%22song%22%3A1%2C%22album%22%3A0%2C%22singer%22%3A0%2C%22tagSong%22%3A1%2C%22mvSong%22%3A0%2C%22bestShow%22%3A1%2C%22songlist%22%3A0%2C%22lyricSong%22%3A0%7D'
+  const url = `https://jadeite.migu.cn/music_search/v3/search/searchAll?isCorrect=0&isCopyright=1&searchSwitch=${searchSwitch}&pageSize=${limit}&text=${encodeURIComponent(keyword)}&pageNo=${page}&sort=0&sid=USS`
+  
+  const raw = await httpGetWithHeaders(url, {
+    uiVersion: 'A_music_3.6.1',
+    deviceId,
+    timestamp: time,
+    sign,
+    channel: '0146921',
+  })
+  
+  if (!raw || raw.code !== '000000') return { list: [], total: 0, allPage: 1, limit, page }
+  const songResultData = raw.songResultData || { resultList: [], totalCount: 0 }
+  
+  const sizeFormate = (size: number) => {
+    if (size < 1024) return size + 'B'
+    if (size < 1048576) return (size / 1024).toFixed(1) + 'K'
+    return (size / 1048576).toFixed(1) + 'M'
+  }
+  
+  const seen = new Set<string>()
+  const list: any[] = []
+  for (const group of songResultData.resultList) {
+    for (const item of group) {
+      if (!item.songId || !item.copyrightId || seen.has(item.copyrightId)) continue
+      seen.add(item.copyrightId)
+      
+      const types: { type: string, size: string }[] = []
+      const _types: Record<string, { size: string }> = {}
+      if (item.audioFormats) {
+        for (const fmt of item.audioFormats) {
+          const sz = sizeFormate(fmt.asize ?? fmt.isize ?? 0)
+          switch (fmt.formatType) {
+            case 'PQ': types.push({ type: '128k', size: sz }); _types['128k'] = { size: sz }; break
+            case 'HQ': types.push({ type: '320k', size: sz }); _types['320k'] = { size: sz }; break
+            case 'SQ': types.push({ type: 'flac', size: sz }); _types.flac = { size: sz }; break
+            case 'ZQ24': types.push({ type: 'flac24bit', size: sz }); _types.flac24bit = { size: sz }; break
+          }
+        }
+      }
+      
+      const singers = item.singerList?.map((s: any) => s.name).join('、') || item.singerName || ''
+      const intervalNum = item.duration || 0
+      const interval = intervalNum
+        ? String(Math.floor(intervalNum / 60)).padStart(2, '0') + ':' + String(Math.floor(intervalNum % 60)).padStart(2, '0')
+        : '00:00'
+      
+      list.push({
+        id: `mg_${item.copyrightId}`,
+        name: item.name || '',
+        singer: singers,
+        source: 'mg' as const,
+        interval,
+        meta: {
+          songId: item.songId,
+          copyrightId: item.copyrightId,
+          albumName: item.album || '',
+          albumId: item.albumId || '',
+          qualitys: types,
+          _qualitys: _types,
+          picUrl: item.img3 || item.img2 || item.img1 || null,
+          lrcUrl: item.lrcUrl || null,
+          trcUrl: item.trcUrl || null,
+          mrcUrl: item.mrcurl || null,
+          toggleMusicInfo: null,
+        },
+      })
+    }
+  }
+  const total = parseInt(songResultData.totalCount) || list.length
+  return { list, total, allPage: Math.max(1, Math.ceil(total / limit)), limit, page }
+}
+
+/**
+ * 搜索音乐 – QQ音乐 (tx)，通过 IPC 调用 renderer SDK
+ */
+const searchTx = async(keyword: string, page: number, limit: number) => {
+  try {
+    return await sendSearchRequest('tx', keyword, page, limit) as any
+  } catch (e) {
+    console.log('tx search error:', (e as Error).message)
+    return { list: [], total: 0, allPage: 1, limit, page }
+  }
+}
+
+/**
+ * 搜索音乐 – 网易云 (wy)，通过 IPC 调用 renderer SDK
+ */
+const searchWy = async(keyword: string, page: number, limit: number) => {
+  try {
+    return await sendSearchRequest('wy', keyword, page, limit) as any
+  } catch (e) {
+    console.log('wy search error:', (e as Error).message)
+    return { list: [], total: 0, allPage: 1, limit, page }
+  }
+}
+
+/**
+ * 音质权重映射
+ */
+const qualityScore: Record<string, number> = {
+  flac24bit: 4,
+  flac: 3,
+  '320k': 2,
+  '128k': 1,
+}
+
+/**
+ * 获取歌曲的最高音质分
+ */
+const getBestQuality = (item: any): number => {
+  const meta = item.meta || item
+  if (!meta._qualitys) return 0
+  let best = 0
+  for (const q of Object.keys(meta._qualitys)) {
+    best = Math.max(best, qualityScore[q] || 0)
+  }
+  return best
+}
+
+/**
+ * 歌曲是否有指定最低音质
+ */
+const hasMinQuality = (item: any, minQ: string): boolean => {
+  const score = qualityScore[minQ] || 0
+  return getBestQuality(item) >= score
+}
+
+/**
+ * 歌手匹配度
+ */
+const singerMatchScore = (itemSinger: string, targetSinger: string): number => {
+  const clean = (s: string) => s.replace(/[\s、，,．·・'"/\\|&!！?？\-_+=\[\]【】()（）：:;；<>《》]/g, '').toLowerCase()
+  const a = clean(itemSinger)
+  const b = clean(targetSinger)
+  if (!a || !b) return 0
+  if (a === b) return 100
+  if (a.includes(b) || b.includes(a)) return 50
+  return 0
+}
+
+/**
+ * 搜索音乐 – 综合搜索
+ */
+const searchMusic = async(keyword: string, source?: string, page = 1, limit = 20, dedup = false, matchSinger?: string, minQuality?: string, order?: string) => {
+  if (source === 'kw') return searchKw(keyword, page, limit)
+  if (source === 'kg') return searchKg(keyword, page, limit)
+  if (source === 'mg') return searchMg(keyword, page, limit)
+  if (source === 'tx') return searchTx(keyword, page, limit)
+  if (source === 'wy') return searchWy(keyword, page, limit)
+  
+  // 默认源优先级（API 参数 > 设置页面 > 硬编码默认）
+  const defaultOrder = ['kg', 'kw', 'mg', 'tx', 'wy']
+  const settingOrder = global.lx.appSetting['openAPI.sourceOrder']
+  const orderList = order
+    ? order.split(',').filter(s => defaultOrder.includes(s))
+    : settingOrder
+      ? settingOrder.split(',').filter(s => defaultOrder.includes(s))
+      : defaultOrder
+  
+  const sourceFns: Record<string, (kw: string, p: number, l: number) => Promise<any>> = {
+    kw: searchKw, kg: searchKg, mg: searchMg, tx: searchTx, wy: searchWy,
+  }
+  
+  // 按 order 指定的顺序搜索
+  const tasks = orderList.map(s => sourceFns[s]?.(keyword, page, limit) ?? Promise.resolve({ list: [], total: 0, allPage: 1, limit, page }))
+  const results = await Promise.allSettled(tasks)
+  
+  let list: any[] = []
+  let total = 0
+  let maxAllPage = 1
+  for (const r of results) {
+    if (r.status === 'fulfilled') {
+      list.push(...r.value.list)
+      total = Math.max(total, r.value.total)
+      maxAllPage = Math.max(maxAllPage, r.value.allPage)
+    }
+  }
+
+  // --- 后处理 ---
+
+  // 1. 音质过滤
+  if (minQuality) {
+    list = list.filter(item => hasMinQuality(item, minQuality))
+  }
+
+  // 2. 歌手匹配排序
+  if (matchSinger) {
+    list.forEach(item => {
+      (item as any)._matchLevel = singerMatchScore(item.singer, matchSinger) >= 100 ? 'exact'
+        : singerMatchScore(item.singer, matchSinger) >= 50 ? 'partial'
+        : 'none'
+      ;(item as any)._matchScore = singerMatchScore(item.singer, matchSinger)
+    })
+    list.sort((a, b) => (b as any)._matchScore - (a as any)._matchScore)
+  }
+
+  // 3. 去重：同歌手+同歌名保留音质最佳
+  if (dedup) {
+    const cleanTitle = (s: string) => s.replace(/[\s、，,．·・'"/\\|&!！?？\-_+=\[\]【】()（）：:;；<>《》]/g, '').toLowerCase()
+    const map = new Map<string, any>()
+    for (const item of list) {
+      const key = `${cleanTitle(item.singer)}|||${cleanTitle(item.name)}`
+      const existing = map.get(key)
+      if (!existing || getBestQuality(item) > getBestQuality(existing)) {
+        map.set(key, item)
+      }
+    }
+    list = [...map.values()]
+  }
+
+  return { list, total, allPage: maxAllPage, page, limit }
 }
 
 let status: LX.OpenAPI.Status = {
@@ -85,7 +541,7 @@ const handleSubscribePlayerStatus = (req: http.IncomingMessage, res: http.Server
 const handleStartServer = async(port: number, ip: string) => new Promise<void>((resolve, reject) => {
   playerStatusKeys = Object.keys(global.lx.player_status) as SubscribeKeys[]
   httpServer = http.createServer((req, res): void => {
-    const [endUrl, query] = `/${req.url?.split('/').at(-1) ?? ''}`.split('?')
+    const [endUrl, query] = (req.url ?? '/').split('?')
     let code = 200
     let msg = 'OK'
     switch (endUrl) {
@@ -202,6 +658,212 @@ const handleStartServer = async(port: number, ip: string) => new Promise<void>((
           msg = 'Error'
         }
         break
+      case '/search': {
+        const params = querystring.parse(query ?? '')
+        const keyword = params.keyword as string
+        const source = params.source as string | undefined
+        const page = parseInt(params.page as string) || 1
+        const limit = parseInt(params.limit as string) || 20
+        const dedup = params.dedup === 'true'
+        const matchSinger = params.matchSinger as string | undefined
+        const minQuality = params.minQuality as string | undefined
+        const order = params.order as string | undefined
+        if (!keyword) {
+          sendResponse(res, 400, { error: true, message: 'Missing keyword' }, 'application/json; charset=utf-8')
+          return
+        }
+        ;(async() => {
+          try {
+            const result = await searchMusic(keyword, source, page, limit, dedup, matchSinger, minQuality, order)
+            sendResponse(res, 200, result, 'application/json; charset=utf-8')
+          } catch (err: any) {
+            console.log(err)
+            sendResponse(res, 500, { error: true, message: err.message || 'Search failed' }, 'application/json; charset=utf-8')
+          }
+        })()
+        return
+      }
+      case '/playlist/create': {
+        if (req.method !== 'POST') {
+          sendResponse(res, 405, { error: true, message: 'Method not allowed, use POST' }, 'application/json; charset=utf-8')
+          return
+        }
+        ;(async() => {
+          try {
+            const body = await parseBody(req)
+            const name = (body.name as string) || 'New List'
+            const id = `userlist_${Date.now()}`
+            await global.lx.event_list.list_create(-1, [{ id, name, locationUpdateTime: null }], false)
+            sendResponse(res, 200, { id, name }, 'application/json; charset=utf-8')
+          } catch (err: any) {
+            console.log(err)
+            sendResponse(res, 500, { error: true, message: err.message || 'Create failed' }, 'application/json; charset=utf-8')
+          }
+        })()
+        return
+      }
+      case '/playlist/add': {
+        if (req.method !== 'POST') {
+          sendResponse(res, 405, { error: true, message: 'Method not allowed, use POST' }, 'application/json; charset=utf-8')
+          return
+        }
+        ;(async() => {
+          try {
+            const body = await parseBody(req)
+            const { listId, musicInfos } = body
+            if (!listId) {
+              sendResponse(res, 400, { error: true, message: 'Missing listId' }, 'application/json; charset=utf-8')
+              return
+            }
+            if (!Array.isArray(musicInfos) || !musicInfos.length) {
+              sendResponse(res, 400, { error: true, message: 'Missing musicInfos' }, 'application/json; charset=utf-8')
+              return
+            }
+            await global.lx.event_list.list_music_add(listId, musicInfos, 'bottom', false)
+            sendResponse(res, 200, { count: musicInfos.length }, 'application/json; charset=utf-8')
+          } catch (err: any) {
+            console.log(err)
+            sendResponse(res, 500, { error: true, message: err.message || 'Add failed' }, 'application/json; charset=utf-8')
+          }
+        })()
+        return
+      }
+      case '/playlist/remove': {
+        if (req.method !== 'DELETE' && req.method !== 'POST') {
+          sendResponse(res, 405, { error: true, message: 'Method not allowed' }, 'application/json; charset=utf-8')
+          return
+        }
+        ;(async() => {
+          try {
+            const body = await parseBody(req)
+            const ids = body.ids as string[]
+            if (!Array.isArray(ids) || !ids.length) {
+              sendResponse(res, 400, { error: true, message: 'Missing ids array' }, 'application/json; charset=utf-8')
+              return
+            }
+            await global.lx.event_list.list_remove(ids, false)
+            sendResponse(res, 200, { removed: ids.length }, 'application/json; charset=utf-8')
+          } catch (err: any) {
+            console.log(err)
+            sendResponse(res, 500, { error: true, message: err.message || 'Remove failed' }, 'application/json; charset=utf-8')
+          }
+        })()
+        return
+      }
+      case '/playlist/songs': {
+        if (req.method !== 'DELETE' && req.method !== 'POST') {
+          sendResponse(res, 405, { error: true, message: 'Method not allowed' }, 'application/json; charset=utf-8')
+          return
+        }
+        ;(async() => {
+          try {
+            const body = await parseBody(req)
+            const listId = body.listId as string
+            const ids = body.ids as string[]
+            if (!listId) {
+              sendResponse(res, 400, { error: true, message: 'Missing listId' }, 'application/json; charset=utf-8')
+              return
+            }
+            if (!Array.isArray(ids) || !ids.length) {
+              sendResponse(res, 400, { error: true, message: 'Missing ids array' }, 'application/json; charset=utf-8')
+              return
+            }
+            await global.lx.event_list.list_music_remove(listId, ids, false)
+            sendResponse(res, 200, { removed: ids.length }, 'application/json; charset=utf-8')
+          } catch (err: any) {
+            console.log(err)
+            sendResponse(res, 500, { error: true, message: err.message || 'Remove songs failed' }, 'application/json; charset=utf-8')
+          }
+        })()
+        return
+      }
+      case '/playlist/list': {
+        const params = querystring.parse(query ?? '')
+        const listId = params.listId as string
+        if (!listId) {
+          sendResponse(res, 400, { error: true, message: 'Missing listId' }, 'application/json; charset=utf-8')
+          return
+        }
+        ;(async() => {
+          try {
+            const songs = await global.lx.worker.dbService.getListMusics(listId) as any[]
+            sendResponse(res, 200, { listId, songs }, 'application/json; charset=utf-8')
+          } catch (err: any) {
+            sendResponse(res, 500, { error: true, message: err.message || 'List failed' }, 'application/json; charset=utf-8')
+          }
+        })()
+        return
+      }
+      case '/playlist/overwrite': {
+        if (req.method !== 'POST') {
+          sendResponse(res, 405, { error: true, message: 'Method not allowed, use POST' }, 'application/json; charset=utf-8')
+          return
+        }
+        ;(async() => {
+          try {
+            const body = await parseBody(req)
+            const listId = body.listId as string
+            const musicInfos = body.musicInfos as any[]
+            if (!listId) {
+              sendResponse(res, 400, { error: true, message: 'Missing listId' }, 'application/json; charset=utf-8')
+              return
+            }
+            if (!Array.isArray(musicInfos)) {
+              sendResponse(res, 400, { error: true, message: 'Missing musicInfos array' }, 'application/json; charset=utf-8')
+              return
+            }
+            await global.lx.event_list.list_music_overwrite(listId, musicInfos, false)
+            sendResponse(res, 200, { count: musicInfos.length }, 'application/json; charset=utf-8')
+          } catch (err: any) {
+            console.log(err)
+            sendResponse(res, 500, { error: true, message: err.message || 'Overwrite failed' }, 'application/json; charset=utf-8')
+          }
+        })()
+        return
+      }
+      case '/player/play': {
+        if (req.method !== 'POST') {
+          sendResponse(res, 405, { error: true, message: 'Method not allowed, use POST' }, 'application/json; charset=utf-8')
+          return
+        }
+        ;(async() => {
+          try {
+            const body = await parseBody(req)
+            const { listId, musicInfo } = body
+            if (!listId || !musicInfo) {
+              sendResponse(res, 400, { error: true, message: 'Missing listId or musicInfo' }, 'application/json; charset=utf-8')
+              return
+            }
+            await sendPlayRequest(listId, musicInfo)
+            sendResponse(res, 200, { ok: true }, 'application/json; charset=utf-8')
+          } catch (err: any) {
+            sendResponse(res, 500, { error: true, message: err.message || 'Play failed' }, 'application/json; charset=utf-8')
+          }
+        })()
+        return
+      }
+      case '/player/list': {
+        ;(async() => {
+          try {
+            const result = await sendQueueRequest()
+            sendResponse(res, 200, result, 'application/json; charset=utf-8')
+          } catch (err: any) {
+            sendResponse(res, 500, { error: true, message: err.message || 'Queue failed' }, 'application/json; charset=utf-8')
+          }
+        })()
+        return
+      }
+      case '/playlists': {
+        ;(async() => {
+          try {
+            const lists = await global.lx.worker.dbService.getAllUserList()
+            sendResponse(res, 200, lists as any, 'application/json; charset=utf-8')
+          } catch (err: any) {
+            sendResponse(res, 500, { error: true, message: err.message || 'Failed' }, 'application/json; charset=utf-8')
+          }
+        })()
+        return
+      }
       default:
         code = 401
         msg = 'Forbidden'

--- a/src/main/modules/openApi/ipcSearch.ts
+++ b/src/main/modules/openApi/ipcSearch.ts
@@ -1,0 +1,65 @@
+// openApi/index.ts 用的 IPC 桥接
+// 用于 tx/wy 搜索 和 播放控制（需要 renderer SDK）
+
+import { mainHandle, mainSend } from '@common/mainIpc'
+
+type PendingRequest = {
+  resolve: (result: any) => void
+  reject: (error: any) => void
+  timer: NodeJS.Timeout
+}
+
+let requestId = 0
+const pending = new Map<number, PendingRequest>()
+
+// 注册回调 handlers
+mainHandle('open_api:search_result', async({ params }: { params: { requestId: number; result?: any; error?: string } }) => {
+  resolvePending(params)
+})
+
+mainHandle('open_api:play_result', async({ params }: { params: { requestId: number; result?: any; error?: string } }) => {
+  resolvePending(params)
+})
+
+mainHandle('open_api:queue_result', async({ params }: { params: { requestId: number; result?: any; error?: string } }) => {
+  resolvePending(params)
+})
+
+const resolvePending = (params: { requestId: number; result?: any; error?: string }) => {
+  const p = pending.get(params.requestId)
+  if (!p) return
+  pending.delete(params.requestId)
+  clearTimeout(p.timer)
+  if (params.error) p.reject(new Error(params.error))
+  else p.resolve(params.result)
+}
+
+const sendRequest = (win: Electron.BrowserWindow, channel: string, params: Record<string, any>): Promise<any> => {
+  return new Promise((resolve, reject) => {
+    const id = ++requestId
+    const timer = setTimeout(() => {
+      pending.delete(id)
+      reject(new Error('IPC timeout'))
+    }, 15000)
+    pending.set(id, { resolve, reject, timer })
+    mainSend(win, channel, { requestId: id, ...params })
+  })
+}
+
+/**
+ * 通过 IPC 调用 renderer 搜索（tx/wy 加密源）
+ */
+export const searchViaIpc = (win: Electron.BrowserWindow, source: string, keyword: string, page: number, limit: number): Promise<any> => {
+  return sendRequest(win, 'open_api:search_request', { source, keyword, page, limit })
+}
+
+/**
+ * 通过 IPC 调用 renderer 播放指定歌曲
+ */
+export const playViaIpc = (win: Electron.BrowserWindow, listId: string, musicInfo: any, songs?: any[]): Promise<any> => {
+  return sendRequest(win, 'open_api:play_request', { listId, musicInfo, songs })
+}
+
+export const queueViaIpc = (win: Electron.BrowserWindow): Promise<any> => {
+  return sendRequest(win, 'open_api:queue_request', {})
+}

--- a/src/main/modules/winMain/main.ts
+++ b/src/main/modules/winMain/main.ts
@@ -153,6 +153,36 @@ export const sendEvent = <T = any>(name: string, params?: T) => {
   mainSend(browserWindow, name, params)
 }
 
+/**
+ * 调用 renderer 端的 handler（rendererHandle 注册的）
+ */
+export const invokeRenderer = async<T = any>(name: string, params?: any): Promise<T> => {
+  if (!browserWindow) throw new Error('main window is undefined')
+  return (browserWindow.webContents as any).ipc.invoke(name, params)
+}
+
+/**
+ * 通过 IPC 请求 renderer 执行搜索（用于 tx/wy 加密源）
+ */
+export const sendSearchRequest = async(source: string, keyword: string, page: number, limit: number): Promise<any> => {
+  if (!browserWindow) throw new Error('main window is undefined')
+  const { searchViaIpc } = await import('@main/modules/openApi/ipcSearch')
+  return searchViaIpc(browserWindow, source, keyword, page, limit)
+}
+
+export const sendPlayRequest = async(listId: string, musicInfo: any): Promise<any> => {
+  if (!browserWindow) throw new Error('main window is undefined')
+  const songs = await global.lx.worker.dbService.getListMusics(listId) as any[]
+  const { playViaIpc } = await import('@main/modules/openApi/ipcSearch')
+  return playViaIpc(browserWindow, listId, musicInfo, songs)
+}
+
+export const sendQueueRequest = async(): Promise<any> => {
+  if (!browserWindow) throw new Error('main window is undefined')
+  const { queueViaIpc } = await import('@main/modules/openApi/ipcSearch')
+  return queueViaIpc(browserWindow)
+}
+
 export const showSelectDialog = async(options: Electron.OpenDialogOptions) => {
   if (!browserWindow) throw new Error('main window is undefined')
   return dialog.showOpenDialog(browserWindow, options)

--- a/src/renderer/core/player/action.ts
+++ b/src/renderer/core/player/action.ts
@@ -125,12 +125,12 @@ const getMusicPlayUrl = async(musicInfo: LX.Music.MusicInfo | LX.Download.ListIt
   })
 }
 
-export const setMusicUrl = (musicInfo: LX.Music.MusicInfo | LX.Download.ListItem, isRefresh?: boolean) => {
+export const setMusicUrl = (musicInfo: LX.Music.MusicInfo | LX.Download.ListItem, isRefresh?: boolean): Promise<void> | void => {
   // if (appSetting['player.autoSkipOnError']) addLoadTimeout()
   if (!diffCurrentMusicInfo(musicInfo)) return
   if (cancelDelayRetry) cancelDelayRetry()
   gettingUrlId = createGettingUrlId(musicInfo)
-  void getMusicPlayUrl(musicInfo, isRefresh).then((url) => {
+  return getMusicPlayUrl(musicInfo, isRefresh).then((url) => {
     if (!url) return
     setResource(url)
   }).catch((err: any) => {

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -27,6 +27,9 @@ import { initSetting } from './store/setting'
 import './worker'
 import { saveViewPrevState } from './utils/data'
 
+import initOpenApiSearch from './utils/openApiSearch'
+
+
 // sync(store, router)
 
 router.afterEach((to) => {
@@ -77,6 +80,9 @@ void getSetting().then(setting => {
   initPlugins(app)
   mountComponents(app)
   app.mount('#root')
+
+  // 注册 Open API 搜索 IPC handler（在 app 挂载后初始化）
+  initOpenApiSearch()
 })
 
 // bubbleCursor()

--- a/src/renderer/utils/openApiSearch.ts
+++ b/src/renderer/utils/openApiSearch.ts
@@ -1,0 +1,114 @@
+// 为 open API 注册 tx/wy 搜索 & 播放 IPC handler
+// Main 进程通过 mainSend → rendererOn → rendererInvoke 回调模式调用
+
+import { rendererInvoke, rendererOn } from '@common/rendererIpc'
+import music from '@renderer/utils/musicSdk'
+import { toNewMusicInfo, deduplicationList } from '@renderer/utils'
+import { markRaw } from '@common/utils/vueTools'
+import { setPlayMusicInfo, setPlayListId, setMusicInfo } from '@renderer/store/player/action'
+import { allMusicList } from '@renderer/store/list/state'
+import { setMusicUrl } from '@renderer/core/player'
+import { setPlay, setStop } from '@renderer/plugins/player'
+import { playInfo, playMusicInfo, musicInfo as _musicInfo } from '@renderer/store/player/state'
+import { getPicPath, getLyricInfo } from '@renderer/core/music'
+
+// ========== 搜索 ==========
+
+const channelSearchRequest = 'open_api:search_request'
+const channelSearchResult = 'open_api:search_result'
+
+const handleSearch = async({ requestId, source, keyword, page, limit }: {
+  requestId: number; source: string; keyword: string; page: number; limit: number
+}) => {
+  try {
+    const sdk = music[source as keyof typeof music] as any
+    if (!sdk?.musicSearch?.search) {
+      await rendererInvoke(channelSearchResult, { requestId, error: `Source ${source} not available` })
+      return
+    }
+    const data = await sdk.musicSearch.search(keyword, page, limit)
+    data.list = deduplicationList(data.list.map((s: any) => markRaw(toNewMusicInfo(s))))
+    await rendererInvoke(channelSearchResult, { requestId, result: data })
+  } catch (e: any) {
+    await rendererInvoke(channelSearchResult, { requestId, error: e.message || 'Search failed' })
+  }
+}
+
+// ========== 播放 ==========
+
+const channelPlayRequest = 'open_api:play_request'
+const channelPlayResult = 'open_api:play_result'
+
+const handlePlay = async({ requestId, listId, musicInfo, songs }: {
+  requestId: number; listId: string; musicInfo: any; songs?: any[]
+}) => {
+  try {
+    if (songs && songs.length) {
+      allMusicList.set(listId, songs)
+    }
+    setPlayListId(listId)
+    setPlayMusicInfo(listId, musicInfo, false)
+    window.lx.isPlayedStop &&= false
+    setStop()
+    window.app_event.pause()
+    await setMusicUrl(musicInfo)
+    // URL loaded, now play
+    setPlay()
+    // Load pic & lyric (fire-and-forget, same as internal handlePlay)
+    void getPicPath({ musicInfo, listId: playMusicInfo.listId }).then((url: string) => {
+      if (musicInfo.id != playMusicInfo.musicInfo?.id || url == _musicInfo.pic) return
+      setMusicInfo({ pic: url })
+      window.app_event.picUpdated()
+    }).catch(_ => _)
+    void getLyricInfo({ musicInfo }).then((lyricInfo) => {
+      if (musicInfo.id != playMusicInfo.musicInfo?.id) return
+      setMusicInfo({
+        lrc: lyricInfo.lyric,
+        tlrc: lyricInfo.tlyric,
+        lxlrc: lyricInfo.lxlyric,
+        rlrc: lyricInfo.rlyric,
+        rawlrc: lyricInfo.rawlrcInfo.lyric,
+      })
+      window.app_event.lyricUpdated()
+    }).catch(_ => _)
+    await rendererInvoke(channelPlayResult, { requestId, result: { ok: true } })
+  } catch (e: any) {
+    await rendererInvoke(channelPlayResult, { requestId, error: e.message || 'Play failed' })
+  }
+}
+
+// ========== 播放队列 ==========
+
+const channelQueueRequest = 'open_api:queue_request'
+const channelQueueResult = 'open_api:queue_result'
+
+const handleQueue = async({ requestId }: { requestId: number }) => {
+  try {
+    const listId = playInfo.playerListId
+    const currentIndex = playInfo.playIndex
+    const list = listId ? (allMusicList.get(listId) ?? []) : []
+    await rendererInvoke(channelQueueResult, {
+      requestId,
+      result: { listId: listId ?? null, currentIndex, count: list.length, list },
+    })
+  } catch (e: any) {
+    await rendererInvoke(channelQueueResult, { requestId, error: e.message || 'Queue failed' })
+  }
+}
+
+// ========== 注册 ==========
+
+export default () => {
+  rendererOn<{ requestId: number; source: string; keyword: string; page: number; limit: number }>(
+    channelSearchRequest,
+    ({ params }) => handleSearch(params).catch(console.error),
+  )
+  rendererOn<{ requestId: number; listId: string; musicInfo: any }>(
+    channelPlayRequest,
+    ({ params }) => handlePlay(params).catch(console.error),
+  )
+  rendererOn<{ requestId: number }>(
+    channelQueueRequest,
+    ({ params }) => handleQueue(params).catch(console.error),
+  )
+}

--- a/src/renderer/views/Setting/components/SettingOpenAPI.vue
+++ b/src/renderer/views/Setting/components/SettingOpenAPI.vue
@@ -14,6 +14,11 @@ dd.gap-top
       .p.small {{ $t('setting__open_api_port') }}
       div
         base-input.gap-left(:class="$style.portInput" :model-value="appSetting['openAPI.port']" type="number" :placeholder="$t('setting__open_api_port_tip')" @update:model-value="setPort")
+    .p.gap-top
+      .p.small 音源优先级
+      div
+        base-input(:class="$style.portInput" :model-value="sourceOrder" :placeholder="'kg,kw,mg,tx,wy'" @update:model-value="setSourceOrder")
+      .p.small.gap-top(style="opacity:0.7") 按逗号分隔，排前面的优先搜索。可只填 kg,kw 限定音源。
 
 dd.gap-top
   div
@@ -23,7 +28,7 @@ dd.gap-top
 </template>
 
 <script>
-// import { computed } from '@common/utils/vueTools'
+import { computed } from '@common/utils/vueTools'
 import { openAPI } from '@renderer/store'
 import { openUrl } from '@common/utils/electron'
 import { appSetting, updateSetting } from '@renderer/store/setting'
@@ -36,12 +41,20 @@ export default {
       updateSetting({ 'openAPI.port': port.trim() })
     }, 500)
 
+    const setSourceOrder = debounce(val => {
+      updateSetting({ 'openAPI.sourceOrder': val.trim() || 'kg,kw,mg,tx,wy' })
+    }, 500)
+
+    const sourceOrder = computed(() => appSetting['openAPI.sourceOrder'] ?? 'kg,kw,mg,tx,wy')
+
     return {
       appSetting,
       updateSetting,
       openAPI,
       openUrl,
       setPort,
+      setSourceOrder,
+      sourceOrder,
     }
   },
 }


### PR DESCRIPTION
Closes #2874

## 概述

在原版 Open API（播放控制 + 状态查询）基础上新增 14 个端点，覆盖歌曲搜索、播放列表 CRUD 和播放控制，并附 AI 集成文档。

## 新增端点

### 搜索

| 端点 | 方法 | 说明 |
|------|------|------|
| `/search` | GET | 5 音源搜索（kw/kg/mg/tx/wy） |

参数：

| 参数 | 默认值 | 说明 |
|------|--------|------|
| `keyword` | 必填 | 搜索关键词 |
| `source` | all | 音源：`kw` `kg` `mg` `tx` `wy` |
| `page` | 1 | 页码 |
| `limit` | 20 | 每页数量 |
| `dedup` | false | 同歌手同歌名去重，保留最高音质 |
| `matchSinger` | — | 按歌手匹配度排序（exact > partial > none），原唱排最前 |
| `minQuality` | — | 最低音质过滤：`128k` `320k` `flac` `flac24bit` |
| `order` | 设置页值 | 音源优先级，如 `mg,kw,kg,tx,wy` |

tx/wy 通过 IPC 回调桥接 renderer SDK 的加密 RPC（`open_api:search_request` / `open_api:search_result`），无需在主进程重新实现签名算法。

返回完整 `MusicInfo` 对象（含 `meta._qualitys` 等），可直接用于播放。

### 播放列表

| 端点 | 方法 | 说明 |
|------|------|------|
| `/playlists` | GET | 列出所有用户歌单 |
| `/playlist/create` | POST | 创建歌单 `{"name":"..."}` |
| `/playlist/add` | POST | 添加歌曲 `{"listId":"..","musicInfos":[...]}` |
| `/playlist/list?listId=xxx` | GET | 查看歌单内容 |
| `/playlist/overwrite` | POST | 覆盖整单歌曲 |
| `/playlist/remove` | POST | 删除歌单 `{"ids":["userlist_xxx"]}` |
| `/playlist/songs` | POST | 删除歌单内歌曲 `{"listId":"..","ids":["kw_123"]}` |

`/playlist/list` + `/playlist/overwrite` 组合使 AI/脚本可以「读取 → 排序/筛选/去重 → 覆盖」，无需每个操作都写服务端端点。

### 播放控制

| 端点 | 方法 | 说明 |
|------|------|------|
| `/player/play` | POST | 播放指定歌单的指定歌曲 `{"listId":"..","musicInfo":{...}}` |
| `/player/list` | GET | 获取当前播放队列 `{listId, currentIndex, count, list}` |

`/player/play` 内部通过 IPC 桥接调用 renderer 的 `setPlayMusicInfo` + `setMusicUrl` → SDK 获取流地址 → `audio.src` → `autoplay`。切歌单时自动 `setPause` + `pause()` 避免 isPlay 状态残留导致新 URL 被丢弃。

## 修复

- **`parseBody`**：自动检测 `\ufffd` 替换字符，回退 `iconv-lite` 尝试 GBK 解码，解决 Windows 终端 curl 发中文 POST 歌单名乱码
- **`httpGet`**：添加 `Accept-Encoding: gzip, deflate` + `zlib` 自动解压，解决音乐源 API 返回压缩数据导致搜索结果乱码

以上修复均使用 Node.js 原生模块 + 纯 JS iconv-lite，Mac/Linux/Windows 全平台兼容。

## 设置页

开放 API 设置页新增"音源优先级"输入框（`openAPI.sourceOrder`），可自定义搜索顺序或限定音源。

## AI 集成

`lx-music-api-skill/` 文件夹包含：

- `SKILL.md`（~170 行）：全部 28 端点文档 + 参数说明 + 决策框架（何时用 curl / batch_add.js / 临时脚本）+ 6 个常用工作流
- `batch_add.js`（~130 行）：批量搜歌脚本（并行 5x 加速 + 增量保存防崩溃 + `--all` 不过滤翻唱）

AI 拿到这些端点后能完成「理解指令 → 搜索原唱 → 过滤翻唱 → 加入歌单 → 排序 → 覆盖」的完整闭环，无需人类干预。

## 改动文件（11 个）

```
src/main/modules/openApi/index.ts                     主变更（搜索 + 全部端点）
src/main/modules/openApi/ipcSearch.ts                 新建（IPC 请求/响应管理）
src/main/modules/winMain/main.ts                      sendSearchRequest / sendPlayRequest / sendQueueRequest
src/common/rendererIpc.ts                             rendererHandle / rendererHandleRemove
src/renderer/utils/openApiSearch.ts                   新建（搜索/播放/队列 IPC handler）
src/renderer/main.ts                                  注册 openApiSearch handler
src/common/types/app_setting.d.ts                     openAPI.sourceOrder 类型
src/common/defaultSetting.ts                          默认值
src/renderer/views/Setting/components/SettingOpenAPI.vue  设置页 UI
lx-music-api-skill/SKILL.md                           AI 使用手册
lx-music-api-skill/batch_add.js                       批量操作脚本
```