### PR TITLE
fix: upgrade undici to 7.28.0, 8.5.0 (CVE-2026-9697)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "node-id3": "^0.2.9",
         "sortablejs": "^1.15.7",
         "tunnel": "^0.0.6",
-        "undici": "^7.25.0",
+        "undici": "^7.28.0",
         "utf-8-validate": "^6.0.6",
         "vue": "~3.3.13",
         "vue-router": "~4.5.1",
@@ -15277,9 +15277,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "node-id3": "^0.2.9",
     "sortablejs": "^1.15.7",
     "tunnel": "^0.0.6",
-    "undici": "^7.25.0",
+    "undici": "^7.28.0",
     "utf-8-validate": "^6.0.6",
     "vue": "~3.3.13",
     "vue-router": "~4.5.1",


### PR DESCRIPTION
## Summary
Upgrade undici from 7.25.0 to 7.28.0, 8.5.0 to fix CVE-2026-9697.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-9697 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-9697` |
| **File** | `package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: undici: undici: Man-in-the-Middle attack via ignored TLS options with SOCKS5 proxy

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-9697` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web application - XSS and injection vulnerabilities can affect end users.

## Changes
- `package.json`
- `package-lock.json`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
