### PR TITLE
修复Wayland环境下有概率启动后不显示窗口的问题

### DIFF
--- a/src/main/modules/winLyric/main.ts
+++ b/src/main/modules/winLyric/main.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { BrowserWindow } from 'electron'
+import { app, BrowserWindow } from 'electron'
 import { debounce, getPlatform, isLinux, isWin } from '@common/utils'
 import { initWindowSize, minHeight, minWidth } from './utils'
 import { mainSend } from '@common/mainIpc'
@@ -72,18 +72,27 @@ const winEvent = () => {
   //   browserWindow.webContents.send('focus')
   // })
 
-  browserWindow.once('ready-to-show', () => {
+  // https://github.com/electron/electron/issues/48859
+  let isWindowShown = false
+  const win = browserWindow
+  const showWindowHandle = () => {
+    if (isWindowShown || browserWindow !== win) return
+    isWindowShown = true
     showWindow()
     if (global.lx.appSetting['desktopLyric.isLock']) {
-      browserWindow!.setIgnoreMouseEvents(true, { forward: !isLinux && global.lx.appSetting['desktopLyric.isHoverHide'] })
+      browserWindow.setIgnoreMouseEvents(true, { forward: !isLinux && global.lx.appSetting['desktopLyric.isHoverHide'] })
     }
     // linux下每次重开时貌似要重新设置置顶
     // if (isLinux && global.lx.appSetting['desktopLyric.isAlwaysOnTop']) {
     //   browserWindow!.setAlwaysOnTop(global.lx.appSetting['desktopLyric.isAlwaysOnTop'], 'screen-saver')
     // }
     if (global.lx.appSetting['desktopLyric.isAlwaysOnTop'] && global.lx.appSetting['desktopLyric.isAlwaysOnTopLoop']) alwaysOnTopTools.startLoop()
-    browserWindow!.blur()
-  })
+    browserWindow.blur()
+  }
+  browserWindow.once('ready-to-show', showWindowHandle)
+  if (process.platform == 'linux' && app.commandLine.getSwitchValue('ozone-platform') == 'wayland') {
+    browserWindow.webContents.once('did-finish-load', showWindowHandle)
+  }
 }
 
 export const createWindow = () => {

--- a/src/main/modules/winMain/main.ts
+++ b/src/main/modules/winMain/main.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, dialog, session } from 'electron'
+import { app, BrowserWindow, dialog, session } from 'electron'
 import path from 'node:path'
 import { createTaskBarButtons, getWindowSizeInfo } from './utils'
 import { getPlatform, isLinux, isWin } from '@common/utils'
@@ -41,13 +41,22 @@ const winEvent = () => {
     global.lx.event_app.main_window_blur()
   })
 
-  browserWindow.once('ready-to-show', () => {
+  // https://github.com/electron/electron/issues/48859
+  let isWindowShown = false
+  const win = browserWindow
+  const showWindowHandle = () => {
+    if (isWindowShown || browserWindow !== win) return
+    isWindowShown = true
     if (!global.envParams.cmdParams.hidden) {
       showWindow()
       setThumbarButtons()
     }
     global.lx.event_app.main_window_ready_to_show()
-  })
+  }
+  browserWindow.once('ready-to-show', showWindowHandle)
+  if (process.platform == 'linux' && app.commandLine.getSwitchValue('ozone-platform') == 'wayland') {
+    browserWindow.webContents.once('did-finish-load', showWindowHandle)
+  }
 
   browserWindow.on('show', () => {
     global.lx.event_app.main_window_show()


### PR DESCRIPTION
### 问题
  在 Electron 40+ 的 Wayland 环境下，`ready-to-show` 事件可能不会触发，
  导致主窗口和桌面歌词窗口创建后一直处于隐藏状态

  ### 修复
  同时监听 `ready-to-show` 和 `did-finish-load`，
  使用先触发的事件显示窗口，并用 `isWindowShown` 防止重复显示。
  `did-finish-load` 只在 Linux Wayland 下作为兜底，避免影响其他平台。
