### PR TITLE
新增专辑搜索功能

### DIFF
--- a/doc/album-search.md
+++ b/doc/album-search.md
@@ -1,0 +1,257 @@
+# 专辑搜索功能开发文档
+
+> 日期：2026-08-19
+> 范围：lx-music-desktop（v2.12.2）搜索结果页新增「专辑」子页签
+> 说明：本文档以**实际代码**为准。
+
+---
+
+## 1. 需求概述
+
+在搜索结果页（`/search`）新增「专辑」子页签，支持：
+
+- 按关键词搜索专辑，覆盖各音乐源；
+- 专辑结果以网格卡片展示，点击进入专辑详情（复用歌单详情页）；
+- 支持多源联合搜索（`all`）与单源搜索；
+- 记忆搜索设置（源/类型），刷新页面后恢复。
+
+---
+
+## 2. 总体架构
+
+### 2.1 路由与 URL 参数
+
+沿用搜索结果页的 URL query 驱动模式：
+
+```
+/search?source=kw&type=album&page=1&text=xxx
+```
+
+- `source`：音乐源 id（`wy` / `kw` / `kg` / `tx` / `mg` / `all`）；
+- `type`：子页签类型（`music` / `songlist` / `album`）；
+- `page`：页码；
+- `text`：搜索关键词。
+
+由 `views/Search/index.vue` 的 `verifyQueryParams`（`beforeRouteEnter` / `beforeRouteUpdate`）解析。
+
+### 2.2 专辑 id 前缀分发（无新路由复用歌单详情页）
+
+专辑列表项 id 统一为 `album__${平台id}` 格式（在各源搜索 SDK 组装）。进入详情时复用 `/songList/detail` 路由，由 `store/songList/action.ts` 新增的 `getListDetailData()` 用正则 `/^album__/` 分发：
+
+```js
+const getListDetailData = (id, source, page) => {
+  return /^album__/.test(id)
+    ? (musicSdk)[source]?.album.getAlbumDetail(id.replace('album__', ''), page)
+    : musicSdk[source]?.songList.getListDetail(id, page)
+}
+```
+
+> 注：`musicSdk` 为 JS 模块，TS 联合类型推断下 `album` / `albumSearch` 非公共属性，访问时需 `(music as any)[source]` 断言（共 3 处：`store/search/album/action.ts`、`store/search/album/state.ts`、`store/songList/action.ts`）。
+
+### 2.3 按能力过滤源列表
+
+`store/search/album/state.ts` 遍历 `music.sources`，仅保留实现了 `albumSearch` 的源，并在尾部追加 `all`（多源联合）：
+
+```ts
+sources = [...music.sources.filter(id => music[id]?.albumSearch), 'all']
+```
+
+实际支持专辑搜索的源：**wy / kw / kg / tx**（mg 未实现，界面在 mg 页签下隐藏专辑子页签）。
+
+### 2.4 数据流
+
+```
+Search/index.vue (URL query)
+  └─ AlbumList/index.vue（网格展示，复用 SongList.vue 组件）
+      └─ useList.ts
+          └─ store/search/album/action.ts search()
+              ├─ 单源：musicSdk[source].albumSearch.search(text, page, limit)
+              └─ all：Promise.all 并发各源，单源失败降级为空壳
+          └─ 排序：similar(keyword, item.name) + sortInsert
+```
+
+---
+
+## 3. 各源搜索接口实现
+
+统一入参：`search(text, page, limit = 20)`；统一出参：`{ list, limit, total, source }`，其中 `list` 项字段为：
+
+```js
+{
+  id: 'album__xxx',     // 带前缀的平台专辑 id
+  name: '专辑名',
+  author: '歌手',
+  time: '发行时间（Y-M-D）',
+  img: '封面图 url',
+  total: 歌曲数,
+  desc: 简介（可为 null）,
+  play_count: '',
+  source: '源 id',
+}
+```
+
+### 3.1 网易云（wy）— `musicSdk/wy/albumSearch.js`
+
+- 接口：eapi `/api/cloudsearch/pc`，POST 参数 `{ s: text, type: 10, limit, total: page == 1, offset: limit * (page - 1) }`（`type: 10` 为专辑）。
+- 响应：`body.result.albums`（数组）、`body.result.albumCount`（总数）。
+- 字段：`artists → author`（`formatSingerName`）、`publishTime → time`（`dateFormat`）、`picUrl → img`、`size → total`。
+
+### 3.2 酷我（kw）— `musicSdk/kw/albumSearch.js`
+
+- 接口：`http://search.kuwo.cn/r.s`，query：`all=${text}&pn=${page-1}&rn=${limit}&ft=album&rformat=json&encoding=utf8&ver=mbox&vipver=MUSIC_8.7.7.0_BCS37&plat=pc&devid=28156413&pay=0&needliveshow=0`。
+- 响应：需经 `objStr2JSON(body)` 解析；`body.albumlist`（数组）、`body.total ?? body.SHOW`（总数）。
+- 字段：`albumid → id`、`artist → author`（`decodeName`）、`pub → time`、`hts_img || img || pic → img`、`musiccnt → total`、`info → desc`。
+
+### 3.3 酷狗（kg）— `musicSdk/kg/albumSearch.js`
+
+- 接口：`http://msearchretry.kugou.com/api/v3/search/album`，query：`keyword=${text}&page=${page}&pagesize=${limit}&showtype=10&filter=0&version=7910&sver=2`。
+- 校验：`body.errcode != 0` 时 `throw new Error('filed')`。
+- 响应：`body.data.info`（数组）、`body.data.total`（总数）。
+- 字段：`albumid → id`、`singername → author`（`decodeName`）、`publishtime → time`（`dateFormat`，毫秒时间戳）、`imgurl.replace('{size}', 240) → img`、`songcount → total`。
+
+### 3.4 腾讯（tx）— `musicSdk/tx/albumSearch.js`
+
+- 接口：`musicu.fcg` 签名接口（`signRequest`），`req_0` 中 `search_type: 2`（0 单曲 / 1 歌手 / 2 专辑 / 3 歌单），`query = text`，`num_per_page = limit`，`page_num = page`，`singerid = 1`，`grp = 1`，`onlysong = 0`。
+- 响应：`body.req.data.body.item_album`（数组）、`body.req.data.body.c_total`（总数）。
+- 字段：`albummid → id`（`album__albummid`）、`singer → author`、`name → 专辑名`、`publish_date → time`、`pic → img`、`song_num → total`。
+
+---
+
+## 4. 各源专辑详情实现
+
+统一入参：`getAlbumDetail(id, page)`（id 为已去除 `album__` 前缀的平台 id）；统一出参复用歌单详情结构 `{ list, page, limit, total, source, info: { name, img, desc, author } }`，`list` 为可直接播放的标准歌曲信息。
+
+### 4.1 网易云（wy）— `musicSdk/wy/album.js`
+
+- 接口：weapi POST `https://music.163.com/weapi/v1/album/${id}`，表单 `{ id }`（weapi 加密）。
+- 校验：`body.code != 200 || !body.album` 时重试（最多 2 次）。
+- 解析：`body.album`（名称/封面/简介/歌手）、`body.songs`（经 `filterList` 转标准歌曲信息），`limit: 1000`。
+
+### 4.2 酷我（kw）— `musicSdk/kw/album.js`
+
+- 接口：`http://search.kuwo.cn/r.s`，query：`pn=${page-1}&rn=1000&stype=albuminfo&albumid=${id}&show_copyright_off=0&encoding=utf&vipver=MUSIC_9.1.0`。
+- 校验：`statusCode != 200 || !body.musiclist` 时重试（最多 2 次）。
+- 解析：`body.musiclist`（经 `filterListDetail` 转标准歌曲信息）、`body.name / img / info / artist`、`limit: 1000`。
+- 挂载方式（`musicSdk/kw/index.js`）为包装器：`album: { getAlbumDetail: (id, page) => album.getAlbumListDetail(id, page) }`。
+
+### 4.3 酷狗（kg）— `musicSdk/kg/album.js`
+
+- 两步请求：
+  1. 专辑曲目：`http://mobiles.kugou.com/api/v3/album/song?version=9108&albumid=${id}&plat=0&pagesize=${limit=200}&area_code=0&page=${page}&with_res_tag=0`，经 `getMusicInfosByList` 转标准歌曲信息；
+  2. 专辑信息：`http://kmrserviceretry.kugou.com/container/v1/album`（POST，`data: [{ album_id: id }]`，取 `album_name / sizable_cover / intro / author_name`）。
+- `albumList.info` 为空时 `Promise.reject`。
+
+### 4.4 腾讯（tx）— `musicSdk/tx/album.js`
+
+- 接口：`https://c.y.qq.com/v8/fcg-bin/fcg_v8_album_detail_cp.fcg?albummid=${id}&format=json&newsong=1`（带 UA/Referer）。
+- 校验：`body.code != 0 || !body.data` 时重试（最多 2 次）。
+- 解析：曲目 `data.getSongInfo ?? data.songlist`（复用 `songList.filterListDetail`）；专辑信息 `data.getAlbumInfo ?? data.albumInfo`；封面由 id 拼 `https://y.gtimg.cn/music/photo_new/T002R500x500M000${id}.jpg`；`limit: list.length + 1`。
+
+---
+
+## 5. Store 实现（`store/search/album/`）
+
+### 5.1 state.ts
+
+- `sources`：支持专辑搜索的源列表（见 2.3），尾部追加 `'all'`；
+- `listInfos`：按源存放 `{ list, page, maxPage, total, source, allList, isEnd }`；
+- `maxPages`：各源最大页数。
+
+### 5.2 action.ts
+
+- `search()`：根据 `sourceId` 决定请求模式。
+  - 单源：`musicSdk[sourceId].albumSearch.search(text, page, limit)`；
+  - `all`：`Promise.all` 并发各源 `search(text, page, limit_all)`（`limit_all = 15`），**单源失败降级为空壳**（返回 `{ list: [], total: 0 }`），保证整体不因个别源失败而中断；
+  - 缓存键：`${page}__${sourceId}__${text}`（对称 `store/search/songlist` 实现）。
+- `setList(s)`：写入 `listInfos[source]`，维护分页信息。
+- `resetListInfo()`：搜索词变化时清空全部缓存与列表。
+- `handleSortList()`：按 `similar(keyword, item.name)` 打分后 `sortInsert` 排序（`all` 模式多源结果合并排序）。
+
+### 5.3 排序细节
+
+```ts
+const limitMap = { all: 15 }  // 单源 limit 默认 18
+```
+
+---
+
+## 6. 界面实现
+
+### 6.1 `views/Search/index.vue`（入口）
+
+- 模板新增页签与分支：
+
+```html
+<base-tab v-model="searchType" :list="searchTypes" @change="handleTypeChange" />
+<album-list v-else-if="searchType == 'album'" v-show="searchText" :page="page" :source-id="source" />
+```
+
+- `searchTypes` computed：`music / songlist / album` 三项；**mg 源时过滤掉 album 项**（`source.value == 'mg'`）。
+- `getSupportList(type)`：`type == 'songlist' ? _songlistSources : type == 'album' ? _albumSources : _sources`（`_sources` 为 music 源列表）。
+- `verifyQueryParams`：URL 中 `type` 指定源的专辑但当前源不支持时，自动回退到 `music` 类型。
+- `handleSourceChange`：切源时若当前类型该源不支持，自动回退到 `music`。
+- `handleTypeChange`：切类型时若当前源不支持，取该类型支持列表第一个源。
+- 顶栏 `sources` 仍基于 `_sources`（music 源列表）展示——源支持度差异由上面几处动态纠正兜底。
+
+### 6.2 `views/Search/AlbumList/index.vue` + `useList.ts`
+
+- 直接复用 `views/songList/List/components/SongList.vue` 网格组件（通过 `visible-source` 属性、`toggle-page` 事件、`scrollTo` / `getScrollTop` expose）。
+- `useList.ts` 监听 `searchText` / `sourceId` / `page` 变化触发 `search()`；带守卫 `if (!sourceListInfo) return`，避免切换至不支持专辑的源时因 `listInfos[source]` 为 undefined 崩溃。
+- 滚动位置恢复：`onBeforeRouteLeave` 时保存 `searchKey` / `searchPosition`，返回时恢复。
+
+### 6.3 国际化
+
+新增键 `search__type_album`：zh-cn `专辑` / zh-tw `專輯` / en-us `Album`。
+
+---
+
+## 7. 问题与修复记录
+
+| # | 问题 | 修复方案 |
+|---|------|----------|
+| 1 | TS2339：`albumSearch` / `album` 不在 musicSdk 联合类型中 | 3 处访问点加 `(music as any)[source]` 断言 |
+| 2 | 网易专辑详情返回空 | 由 eapi 改为 weapi POST `https://music.163.com/weapi/v1/album/{id}`，参数 `{ id }` |
+| 3 | 运行时崩溃 `Cannot read properties of undefined (reading 'list')`（切到不支持专辑的源时） | 双保险：`useList.ts#search` 加守卫 + `Search/index.vue` 用 `getSupportList` 纠正非法源 |
+| 4 | eslint 误报 `_songlistSources` / `_albumSources` 未使用 | 删除 `node_modules/.cache/eslint-webpack-plugin` 后重启 dev |
+| 5 | 腾讯旧版 `client_search` 接口失效返回空 body | 改为 `musicu.fcg` 签名接口（`signRequest`，`search_type: 2`），解析 `body.req.data.body.item_album` |
+
+---
+
+## 8. 文件清单
+
+**新增文件**
+
+| 文件 | 说明 |
+|------|------|
+| `src/renderer/utils/musicSdk/wy/albumSearch.js` | 网易云专辑搜索（eapi type:10） |
+| `src/renderer/utils/musicSdk/kw/albumSearch.js` | 酷我专辑搜索（r.s?ft=album） |
+| `src/renderer/utils/musicSdk/kg/albumSearch.js` | 酷狗专辑搜索（v3/search/album） |
+| `src/renderer/utils/musicSdk/tx/albumSearch.js` | 腾讯专辑搜索（musicu.fcg search_type:2） |
+| `src/renderer/utils/musicSdk/wy/album.js` | 网易云专辑详情（weapi v1/album） |
+| `src/renderer/utils/musicSdk/kw/album.js` | 酷我专辑详情（r.s?stype=albuminfo） |
+| `src/renderer/utils/musicSdk/kg/album.js` | 酷狗专辑详情（v3/album/song + container/v1/album） |
+| `src/renderer/utils/musicSdk/tx/album.js` | 腾讯专辑详情（fcg_v8_album_detail_cp） |
+| `src/renderer/store/search/album/index.ts` | Store 出口 |
+| `src/renderer/store/search/album/state.ts` | 状态与源能力过滤 |
+| `src/renderer/store/search/album/action.ts` | 搜索动作（单源/all、缓存、排序） |
+| `src/renderer/views/Search/AlbumList/index.vue` | 专辑子页签视图 |
+| `src/renderer/views/Search/AlbumList/useList.ts` | 列表逻辑（分页/守卫/滚动恢复） |
+
+**修改文件**
+
+| 文件 | 改动 |
+|------|------|
+| `src/renderer/utils/musicSdk/{wy,kw,kg,tx}/index.js` | 挂载 `albumSearch` + `album`（kw 为包装器形式） |
+| `src/renderer/views/Search/index.vue` | 「专辑」页签、`<album-list>` 分支、`getSupportList`、`handleTypeChange` / `handleSourceChange`、`searchTypes` mg 过滤 |
+| `src/renderer/store/songList/action.ts` | 新增 `getListDetailData()` 按 `album__` 前缀分发详情 |
+| `src/lang/{zh-cn,zh-tw,en-us}.json` | 新增 `search__type_album` |
+
+---
+
+## 9. 遗留事项 / 后续优化
+
+- **mg 专辑搜索**：未实现 `albumSearch`，如后续补充需新增 SDK 并按能力过滤自动接入；
+- **接口字段实测**：各源分页数、`total` 准确性（尤其 tx `c_total`、kg `data.total`）未做大规模回归；
+- **封面防盗链**：部分源封面（如酷我 `sycdn` 图床、腾讯 `y.gtimg.cn`）在无 UA/Referer 环境下可能加载失败，尚未统一处理；
+- **搜索设置边界**：`getSearchSetting` / `setSearchSetting` 对 `type: 'album'` 的兼容（旧设置缺少该键时回退路径）；
+- **回归点**：`/songList/detail` 歌单详情正常路径、`all` 模式多源并发稳定性、切换源/类型时非法参数兜底。

--- a/src/lang/en-us.json
+++ b/src/lang/en-us.json
@@ -289,6 +289,7 @@
   "search__hot_search": "Top Searches",
   "search__type_music": "Song",
   "search__type_songlist": "Playlist",
+  "search__type_album": "Album",
   "search__welcome": "Search what I want~~ 😉",
   "setting": "Settings",
   "setting__about": "About LX Music",

--- a/src/lang/zh-cn.json
+++ b/src/lang/zh-cn.json
@@ -289,6 +289,7 @@
   "search__hot_search": "热门搜索",
   "search__type_music": "歌曲",
   "search__type_songlist": "歌单",
+  "search__type_album": "专辑",
   "search__welcome": "搜我所想~~😉",
   "setting": "设置",
   "setting__about": "关于 LX Music",

--- a/src/lang/zh-tw.json
+++ b/src/lang/zh-tw.json
@@ -289,6 +289,7 @@
   "search__hot_search": "熱門搜尋",
   "search__type_music": "歌曲",
   "search__type_songlist": "歌單",
+  "search__type_album": "專輯",
   "search__welcome": "搜我所想~~😉",
   "setting": "設定",
   "setting__about": "關於 LX Music",

--- a/src/renderer/store/search/album/action.ts
+++ b/src/renderer/store/search/album/action.ts
@@ -1,0 +1,128 @@
+import { markRawList } from '@common/utils/vueTools'
+import music from '@renderer/utils/musicSdk'
+import { sortInsert, similar } from '@common/utils/common'
+
+import type { ListInfoItem } from './state'
+import { sources, maxPages, listInfos } from './state'
+
+interface SearchResult {
+  list: ListInfoItem[]
+  limit: number
+  total: number
+  source: LX.OnlineSource
+}
+
+
+/**
+ * 按搜索关键词重新排序列表
+ * @param list 专辑列表
+ * @param keyword 搜索关键词
+ * @returns 排序后的列表
+ */
+const handleSortList = (list: ListInfoItem[], keyword: string) => {
+  let arr: any[] = []
+  for (const item of list) {
+    sortInsert(arr, {
+      num: similar(keyword, item.name),
+      data: item,
+    })
+  }
+  return arr.map(item => item.data).reverse()
+}
+
+
+let maxTotals: Partial<Record<LX.OnlineSource, number>> = {
+
+}
+const setLists = (results: SearchResult[], page: number, text: string): ListInfoItem[] => {
+  let totals = []
+  let limit = 0
+  let list = []
+  for (const source of results) {
+    list.push(...source.list)
+    totals.push(source.total)
+    maxTotals[source.source] = source.total
+    maxPages[source.source] = Math.ceil(source.total / source.limit)
+    limit = Math.max(source.limit, limit)
+  }
+  markRawList(list)
+
+  let listInfo = listInfos.all
+  const total = Math.max(0, ...totals)
+  if (page == 1 || (total && list.length)) listInfo.total = total
+  else listInfo.total = limit * page
+  listInfo.page = page
+  listInfo.list = handleSortList(list, text)
+  if (text && !list.length && page == 1) listInfo.noItemLabel = window.i18n.t('no_item')
+  else listInfo.noItemLabel = ''
+  return listInfo.list
+}
+
+const setList = (datas: SearchResult, page: number, text: string): ListInfoItem[] => {
+  // console.log(datas.source, datas.list)
+  let listInfo = listInfos[datas.source]!
+  listInfo.list = markRawList(datas.list)
+  if (page == 1 || (datas.total && datas.list.length)) listInfo.total = datas.total
+  else listInfo.total = datas.limit * page
+  listInfo.page = page
+  listInfo.limit = datas.limit
+  if (text && !datas.list.length && page == 1) listInfo.noItemLabel = window.i18n.t('no_item')
+  else listInfo.noItemLabel = ''
+  return listInfo.list
+}
+
+export const resetListInfo = (sourceId: LX.OnlineSource | 'all'): [] => {
+  let listInfo = listInfos[sourceId]
+  if (!listInfo) return []
+  listInfo.page = 1
+  listInfo.limit = 20
+  listInfo.total = 0
+  listInfo.list = []
+  listInfo.key = null
+  listInfo.noItemLabel = ''
+  listInfo.tagId = ''
+  listInfo.sortId = ''
+  return []
+}
+
+export const search = async(text: string, page: number, sourceId: LX.OnlineSource | 'all'): Promise<ListInfoItem[]> => {
+  const listInfo = listInfos[sourceId]!
+  if (!text) return resetListInfo(sourceId)
+  const key = `${page}__${sourceId}__${text}`
+  if (listInfo.key == key && listInfo.list.length) return listInfo.list
+  if (sourceId == 'all') {
+    listInfo.noItemLabel = window.i18n.t('list__loading')
+    listInfo.key = key
+    let task = []
+    for (const source of sources) {
+      if (source == 'all' || (page > 1 && page > (maxPages[source]!))) continue
+      task.push(((music as any)[source]?.albumSearch.search(text, page, listInfos.all.limit) ?? Promise.reject(new Error('source not found: ' + source))).catch((error: any) => {
+        console.log(error)
+        return {
+          list: [],
+          total: 0,
+          limit: listInfos.all.limit,
+          source,
+        }
+      }))
+    }
+    return Promise.all(task).then((results: SearchResult[]) => {
+      if (key != listInfo.key) return []
+      return setLists(results, page, text)
+    })
+  } else {
+    if (listInfo?.key == key && listInfo?.list.length) return listInfo?.list
+    if (!(music as any)[sourceId]?.albumSearch) return resetListInfo(sourceId)
+    listInfo.noItemLabel = window.i18n.t('list__loading')
+    listInfo.key = key
+    return ((music as any)[sourceId]?.albumSearch.search(text, page, listInfo.limit).then((data: SearchResult) => {
+      if (key != listInfo.key) return []
+      return setList(data, page, text)
+    }) ?? Promise.reject(new Error('source not found: ' + sourceId))).catch((error: any) => {
+      resetListInfo(sourceId)
+      listInfo.noItemLabel = window.i18n.t('list__load_failed')
+      console.log(error)
+      throw error
+    })
+  }
+}

--- a/src/renderer/store/search/album/index.ts
+++ b/src/renderer/store/search/album/index.ts
@@ -1,0 +1,3 @@
+
+export * from './action'
+export * from './state'

--- a/src/renderer/store/search/album/state.ts
+++ b/src/renderer/store/search/album/state.ts
@@ -1,0 +1,46 @@
+import { reactive, markRaw } from '@common/utils/vueTools'
+import music from '@renderer/utils/musicSdk'
+
+import { type ListInfo } from '@renderer/store/songList/state'
+
+export type { ListInfoItem } from '@renderer/store/songList/state'
+
+export const sources: Array<LX.OnlineSource | 'all'> = markRaw([])
+
+export type AlbumSearchListInfo = Omit<ListInfo, 'source'>
+
+
+interface ListInfos extends Partial<Record<LX.OnlineSource, AlbumSearchListInfo>> {
+  'all': AlbumSearchListInfo
+}
+
+
+export const listInfos: ListInfos = markRaw({
+  all: reactive<AlbumSearchListInfo>({
+    page: 1,
+    limit: 15,
+    total: 0,
+    list: [],
+    key: null,
+    noItemLabel: '',
+    tagId: '',
+    sortId: '',
+  }),
+})
+export const maxPages: Partial<Record<LX.OnlineSource, number>> = {}
+for (const source of music.sources) {
+  if (!(music as any)[source.id as LX.OnlineSource]?.albumSearch) continue
+  sources.push(source.id as LX.OnlineSource)
+  listInfos[source.id as LX.OnlineSource] = reactive<AlbumSearchListInfo>({
+    page: 1,
+    limit: 18,
+    total: 0,
+    list: [],
+    key: null,
+    noItemLabel: '',
+    tagId: '',
+    sortId: '',
+  })
+  maxPages[source.id as LX.OnlineSource] = 0
+}
+sources.push('all')

--- a/src/renderer/store/songList/action.ts
+++ b/src/renderer/store/songList/action.ts
@@ -122,6 +122,18 @@ export const getAndSetList = async(source: LX.OnlineSource, tabId: string, sortI
 }
 
 /**
+ * 获取详情数据（歌单或专辑，专辑 id 带 album__ 前缀）
+ * @param id 歌单/专辑id
+ * @param source 来源
+ * @param page 页数
+ */
+const getListDetailData = (id: string, source: LX.OnlineSource, page: number) => {
+  return /^album__/.test(id)
+    ? (musicSdk as any)[source]?.album.getAlbumDetail(id.replace('album__', ''), page)
+    : musicSdk[source]?.songList.getListDetail(id, page)
+}
+
+/**
  * 获取歌单内单页歌曲
  * @param id 歌单id
  * @param source 歌单源
@@ -132,7 +144,7 @@ export const getListDetail = async(id: string, source: LX.OnlineSource, page: nu
   let key = `sdetail__${source}__${id}__${page}`
   if (!isRefresh && cache.has(key)) return cache.get(key)
 
-  return musicSdk[source]?.songList.getListDetail(id, page).then((result: ListDetailInfo) => {
+  return getListDetailData(id, source, page).then((result: ListDetailInfo) => {
     result.list = markRawList(deduplicationList(result.list.map(m => toNewMusicInfo(m)) as LX.Music.MusicInfoOnline[]))
     cache.set(key, result)
     return result
@@ -154,7 +166,7 @@ export const getListDetailAll = async(id: string, source: LX.OnlineSource, isRef
     if (isRefresh && cache.has(key)) cache.delete(key)
     return cache.has(key)
       ? Promise.resolve(cache.get(key))
-      : musicSdk[source]?.songList.getListDetail(id, page).then((result: ListDetailInfo) => {
+      : getListDetailData(id, source, page).then((result: ListDetailInfo) => {
         result.list = markRawList(deduplicationList(result.list.map(m => toNewMusicInfo(m)) as LX.Music.MusicInfoOnline[]))
         cache.set(key, result)
         return result

--- a/src/renderer/utils/musicSdk/kg/albumSearch.js
+++ b/src/renderer/utils/musicSdk/kg/albumSearch.js
@@ -1,0 +1,28 @@
+import { httpFetch } from '../../request'
+import { decodeName, dateFormat } from '../../index'
+
+export default {
+  search(text, page, limit = 20) {
+    // http://msearchretry.kugou.com/api/v3/search/album?keyword=xxx&page=1&pagesize=20&showtype=10&filter=0&version=7910&sver=2
+    return httpFetch(`http://msearchretry.kugou.com/api/v3/search/album?keyword=${encodeURIComponent(text)}&page=${page}&pagesize=${limit}&showtype=10&filter=0&version=7910&sver=2`)
+      .promise.then(({ body }) => {
+        if (body.errcode != 0) throw new Error('filed')
+        return {
+          list: (body.data?.info ?? []).map(item => ({
+            play_count: '',
+            id: `album__${item.albumid}`,
+            author: decodeName(item.singername),
+            name: decodeName(item.albumname),
+            time: item.publishtime ? dateFormat(item.publishtime, 'Y-M-D') : '',
+            img: item.imgurl && item.imgurl.replace('{size}', 240),
+            total: item.songcount,
+            desc: null,
+            source: 'kg',
+          })),
+          limit,
+          total: body.data?.total ?? 0,
+          source: 'kg',
+        }
+      })
+  },
+}

--- a/src/renderer/utils/musicSdk/kg/index.js
+++ b/src/renderer/utils/musicSdk/kg/index.js
@@ -2,6 +2,8 @@ import leaderboard from './leaderboard'
 import { apis } from '../api-source'
 import songList from './songList'
 import musicSearch from './musicSearch'
+import albumSearch from './albumSearch'
+import album from './album'
 import pic from './pic'
 import lyric from './lyric'
 import hotSearch from './hotSearch'
@@ -13,6 +15,8 @@ const kg = {
   leaderboard,
   songList,
   musicSearch,
+  albumSearch,
+  album,
   hotSearch,
   comment,
   getMusicUrl(songInfo, type) {

--- a/src/renderer/utils/musicSdk/kw/album.js
+++ b/src/renderer/utils/musicSdk/kw/album.js
@@ -1,5 +1,5 @@
 import { httpFetch } from '../../request'
-import { decodeName } from '../../index'
+import { decodeName, formatPlayTime } from '../../index'
 import { formatSinger, objStr2JSON } from './util'
 
 // let requestObj_list
@@ -57,7 +57,7 @@ export default {
         albumId,
         songmid: item.id,
         source: 'kw',
-        interval: null,
+        interval: formatPlayTime(parseInt(item.duration)),
         img: item.pic,
         lrc: null,
         otherSource: null,

--- a/src/renderer/utils/musicSdk/kw/albumSearch.js
+++ b/src/renderer/utils/musicSdk/kw/albumSearch.js
@@ -1,0 +1,28 @@
+import { httpFetch } from '../../request'
+import { decodeName } from '../../index'
+import { objStr2JSON } from './util'
+
+export default {
+  search(text, page, limit = 20) {
+    return httpFetch(`http://search.kuwo.cn/r.s?all=${encodeURIComponent(text)}&pn=${page - 1}&rn=${limit}&rformat=json&encoding=utf8&ver=mbox&vipver=MUSIC_8.7.7.0_BCS37&plat=pc&devid=28156413&ft=album&pay=0&needliveshow=0`)
+      .promise.then(({ body }) => {
+        body = objStr2JSON(body)
+        return {
+          list: (body.albumlist ?? []).map(item => ({
+            play_count: '',
+            id: `album__${item.albumid}`,
+            author: decodeName(item.artist),
+            name: decodeName(item.name),
+            time: item.pub || '',
+            img: item.hts_img || item.img || `http://img3.sycdn.kuwo.cn/star/albumcover/${item.pic}`,
+            total: item.musiccnt,
+            desc: item.info ? decodeName(item.info) : null,
+            source: 'kw',
+          })),
+          limit,
+          total: parseInt(body.total ?? body.SHOW ?? 0),
+          source: 'kw',
+        }
+      })
+  },
+}

--- a/src/renderer/utils/musicSdk/kw/index.js
+++ b/src/renderer/utils/musicSdk/kw/index.js
@@ -1,6 +1,8 @@
 import { httpFetch } from '../../request'
 import tipSearch from './tipSearch'
 import musicSearch from './musicSearch'
+import albumSearch from './albumSearch'
+import album from './album'
 import { formatSinger } from './util'
 import leaderboard from './leaderboard'
 import lyric from './lyric'
@@ -34,8 +36,12 @@ const kw = {
 
   tipSearch,
   musicSearch,
+  albumSearch,
   leaderboard,
   songList,
+  album: {
+    getAlbumDetail: (id, page) => album.getAlbumListDetail(id, page),
+  },
   hotSearch,
   comment,
   getLyric(songInfo, isGetLyricx) {

--- a/src/renderer/utils/musicSdk/mg/index.js
+++ b/src/renderer/utils/musicSdk/mg/index.js
@@ -2,6 +2,7 @@ import { apis } from '../api-source'
 import leaderboard from './leaderboard'
 import songList from './songList'
 import musicSearch from './musicSearch'
+import album from './album'
 import pic from './pic'
 import lyric from './lyric'
 import hotSearch from './hotSearch'
@@ -12,6 +13,7 @@ const mg = {
   // tipSearch,
   songList,
   musicSearch,
+  album,
   leaderboard,
   hotSearch,
   comment,

--- a/src/renderer/utils/musicSdk/tx/album.js
+++ b/src/renderer/utils/musicSdk/tx/album.js
@@ -1,0 +1,38 @@
+import { httpFetch } from '../../request'
+import { decodeName } from '../../index'
+import songList from './songList'
+
+export default {
+  successCode: 0,
+  getAlbumDetail(id, page = 1, tryNum = 0) {
+    if (tryNum > 2) return Promise.reject(new Error('try max num'))
+
+    const requestObj = httpFetch(`https://c.y.qq.com/v8/fcg-bin/fcg_v8_album_detail_cp.fcg?albummid=${id}&format=json&newsong=1`, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)',
+        Referer: 'https://y.qq.com/',
+      },
+    })
+    return requestObj.promise.then(({ body }) => {
+      if (!body || body.code !== this.successCode || !body.data) return this.getAlbumDetail(id, page, ++tryNum)
+      const data = body.data
+      const albumInfo = data.getAlbumInfo ?? data.albumInfo ?? {}
+      const list = songList.filterListDetail(data.getSongInfo ?? data.songlist ?? [])
+      return {
+        list,
+        page,
+        limit: list.length + 1,
+        total: list.length,
+        source: 'tx',
+        info: {
+          name: albumInfo.Falbum_name,
+          img: `https://y.gtimg.cn/music/photo_new/T002R500x500M000${id}.jpg`,
+          desc: (data.getAlbumDesc ?? {}).Falbum_desc,
+          author: decodeName(data.singerInfo?.[0]?.Fsinger_name),
+          company: data.company?.name,
+          time: albumInfo.Fpublic_time,
+        },
+      }
+    })
+  },
+}

--- a/src/renderer/utils/musicSdk/tx/albumSearch.js
+++ b/src/renderer/utils/musicSdk/tx/albumSearch.js
@@ -1,0 +1,76 @@
+import { signRequest } from './utils'
+
+export default {
+  search(text, page, limit = 20) {
+    const searchRequest = signRequest({
+      comm: {
+        ct: '11',
+        cv: '14090508',
+        v: '14090508',
+        tmeAppID: 'qqmusic',
+        phonetype: 'EBG-AN10',
+        deviceScore: '553.47',
+        devicelevel: '50',
+        newdevicelevel: '20',
+        rom: 'HuaWei/EMOTION/EmotionUI_14.2.0',
+        os_ver: '12',
+        OpenUDID: '0',
+        OpenUDID2: '0',
+        QIMEI36: '0',
+        udid: '0',
+        chid: '0',
+        aid: '0',
+        oaid: '0',
+        taid: '0',
+        tid: '0',
+        wid: '0',
+        uid: '0',
+        sid: '0',
+        modeSwitch: '6',
+        teenMode: '0',
+        ui_mode: '2',
+        nettype: '1020',
+        v4ip: '',
+      },
+      req: {
+        module: 'music.search.SearchCgiService',
+        method: 'DoSearchForQQMusicMobile',
+        param: {
+          search_type: 2, // 0 单曲, 1 歌手, 2 专辑, 3 歌单
+          searchid: Math.random().toString().slice(2),
+          query: text,
+          page_num: page,
+          num_per_page: limit,
+          highlight: 0,
+          nqc_flag: 0,
+          multi_zhida: 0,
+          cat: 2,
+          grp: 1,
+          sin: 0,
+          sem: 0,
+        },
+      },
+    })
+    return searchRequest.then(({ body }) => {
+      if (!body || !body.req || body.code != 0 || body.req.code != 0) throw new Error('搜索失败')
+      const reqData = body.req.data ?? {}
+      const albumList = reqData.body?.item_album ?? []
+      return {
+        list: albumList.map(item => ({
+          play_count: '',
+          id: `album__${item.albummid}`,
+          author: item.singer,
+          name: item.name,
+          time: item.publish_date || item.description || '',
+          img: item.pic || `https://y.gtimg.cn/music/photo_new/T002R500x500M000${item.albummid}.jpg`,
+          total: item.song_num,
+          desc: null,
+          source: 'tx',
+        })),
+        limit,
+        total: reqData.meta?.estimate_sum ?? 0,
+        source: 'tx',
+      }
+    })
+  },
+}

--- a/src/renderer/utils/musicSdk/tx/index.js
+++ b/src/renderer/utils/musicSdk/tx/index.js
@@ -2,6 +2,8 @@ import leaderboard from './leaderboard'
 import lyric from './lyric'
 import songList from './songList'
 import musicSearch from './musicSearch'
+import albumSearch from './albumSearch'
+import album from './album'
 import { apis } from '../api-source'
 import hotSearch from './hotSearch'
 import comment from './comment'
@@ -12,6 +14,8 @@ const tx = {
   leaderboard,
   songList,
   musicSearch,
+  albumSearch,
+  album,
   hotSearch,
   comment,
 

--- a/src/renderer/utils/musicSdk/wy/album.js
+++ b/src/renderer/utils/musicSdk/wy/album.js
@@ -1,0 +1,99 @@
+import { httpFetch } from '../../request'
+import { weapi } from './utils/crypto'
+import { formatPlayTime, sizeFormate } from '../../index'
+import { formatSingerName } from '../utils'
+
+export default {
+  successCode: 200,
+  getSinger(singers) {
+    let arr = []
+    singers?.forEach(singer => {
+      arr.push(singer.name)
+    })
+    return arr.join('、')
+  },
+  filterList(rawList) {
+    const list = []
+    rawList.forEach(item => {
+      const types = []
+      const _types = {}
+      let size
+      if (item.hr) {
+        size = item.hr.size ? sizeFormate(item.hr.size) : null
+        types.push({ type: 'flac24bit', size })
+        _types.flac24bit = {
+          size,
+        }
+      }
+      if (item.sq) {
+        size = item.sq.size ? sizeFormate(item.sq.size) : null
+        types.push({ type: 'flac', size })
+        _types.flac = {
+          size,
+        }
+      }
+      if (item.h) {
+        size = item.h.size ? sizeFormate(item.h.size) : null
+        types.push({ type: '320k', size })
+        _types['320k'] = {
+          size,
+        }
+      }
+      if (item.l) {
+        size = item.l.size ? sizeFormate(item.l.size) : null
+        types.push({ type: '128k', size })
+        _types['128k'] = {
+          size,
+        }
+      }
+      types.reverse()
+
+      list.push({
+        singer: this.getSinger(item.ar),
+        name: item.name ?? '',
+        albumName: item.al?.name,
+        albumId: item.al?.id,
+        source: 'wy',
+        interval: formatPlayTime(item.dt / 1000),
+        songmid: item.id,
+        img: item.al?.picUrl,
+        lrc: null,
+        otherSource: null,
+        types,
+        _types,
+        typeUrl: {},
+      })
+    })
+    return list
+  },
+  getAlbumDetail(id, page, tryNum = 0) {
+    if (tryNum > 2) return Promise.reject(new Error('try max num'))
+
+    const requestObj = httpFetch(`https://music.163.com/weapi/v1/album/${id}`, {
+      method: 'post',
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36',
+        origin: 'https://music.163.com',
+      },
+      form: weapi({ id }),
+    })
+    return requestObj.promise.then(({ body }) => {
+      if (!body || body.code !== this.successCode || !body.album) return this.getAlbumDetail(id, page, ++tryNum)
+      const album = body.album
+      const list = this.filterList(body.songs ?? [])
+      return {
+        list,
+        page,
+        limit: 1000,
+        total: album.size ?? list.length,
+        source: 'wy',
+        info: {
+          name: album.name,
+          img: album.picUrl,
+          desc: album.description,
+          author: formatSingerName(Array.isArray(album.artists) ? album.artists : [album.artist]),
+        },
+      }
+    })
+  },
+}

--- a/src/renderer/utils/musicSdk/wy/albumSearch.js
+++ b/src/renderer/utils/musicSdk/wy/albumSearch.js
@@ -1,0 +1,39 @@
+import { eapiRequest } from './utils/index'
+import { dateFormat } from '../../index'
+import { formatSingerName } from '../utils'
+
+export default {
+  successCode: 200,
+  filterList(rawData) {
+    return rawData.map(item => ({
+      play_count: '',
+      id: `album__${item.id}`,
+      author: formatSingerName(item.artists),
+      name: item.name,
+      time: item.publishTime ? dateFormat(item.publishTime, 'Y-M-D') : '',
+      img: item.picUrl,
+      total: item.size,
+      desc: null,
+      source: 'wy',
+    }))
+  },
+  search(text, page, limit = 20) {
+    return eapiRequest('/api/cloudsearch/pc', {
+      s: text,
+      type: 10, // 1: 单曲, 10: 专辑, 100: 歌手, 1000: 歌单, 1002: 用户, 1004: MV, 1006: 歌词, 1009: 电台, 1014: 视频
+      limit,
+      total: page == 1,
+      offset: limit * (page - 1),
+    })
+      .promise.then(({ body }) => {
+        if (body.code != this.successCode) throw new Error('filed')
+        const result = body.result ?? {}
+        return {
+          list: this.filterList(result.albums ?? []),
+          limit,
+          total: result.albumCount ?? 0,
+          source: 'wy',
+        }
+      })
+  },
+}

--- a/src/renderer/utils/musicSdk/wy/index.js
+++ b/src/renderer/utils/musicSdk/wy/index.js
@@ -4,6 +4,8 @@ import getLyric from './lyric'
 import getMusicInfo from './musicInfo'
 import musicSearch from './musicSearch'
 import songList from './songList'
+import albumSearch from './albumSearch'
+import album from './album'
 import hotSearch from './hotSearch'
 import comment from './comment'
 // import tipSearch from './tipSearch'
@@ -13,6 +15,8 @@ const wy = {
   leaderboard,
   musicSearch,
   songList,
+  albumSearch,
+  album,
   hotSearch,
   comment,
   getMusicUrl(songInfo, type) {

--- a/src/renderer/views/Search/AlbumList/index.vue
+++ b/src/renderer/views/Search/AlbumList/index.vue
@@ -1,0 +1,73 @@
+<template>
+  <div :class="$style.container">
+    <SongList ref="listRef" :list-info="listInfo" :visible-source="sourceId == 'all'" @toggle-page="togglePage" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { watch } from '@common/utils/vueTools'
+import { searchText } from '@renderer/store/search/state'
+import { useRouter, useRoute } from '@common/utils/vueRouter'
+import useList, { type SearchSource } from './useList'
+import SongList from '@renderer/views/songList/List/components/SongList.vue'
+
+interface Props {
+  sourceId: SearchSource
+  page: number
+}
+
+const props = defineProps<Props>()
+const router = useRouter()
+const route = useRoute()
+
+const {
+  listRef,
+  listInfo,
+  search,
+} = useList()
+
+watch(() => [props.sourceId, props.page], ([sourceId, page]) => {
+  setTimeout(() => {
+    search(searchText.value, sourceId as SearchSource, page as number || 1)
+  })
+})
+watch(searchText, (searchText) => {
+  setTimeout(() => {
+    search(searchText, props.sourceId, props.page)
+  })
+}, {
+  immediate: true,
+})
+
+const togglePage = (page: number) => {
+  void router.replace({
+    path: route.path,
+    query: {
+      ...route.query,
+      page,
+    },
+  })
+  // search(searchText.value, props.sourceId, page)
+}
+
+
+</script>
+
+
+<style lang="less" module>
+.container {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  padding-top: 5px;
+}
+
+// .list {
+//   overflow: hidden;
+//   height: 100%;
+//   flex: auto;
+// }
+
+</style>

--- a/src/renderer/views/Search/AlbumList/useList.ts
+++ b/src/renderer/views/Search/AlbumList/useList.ts
@@ -1,0 +1,57 @@
+import { onBeforeRouteLeave } from '@common/utils/vueRouter'
+import { ref, nextTick } from '@common/utils/vueTools'
+import { addHistoryWord } from '@renderer/store/search/action'
+// import { useI18n } from '@renderer/plugins/i18n'
+// import { } from '@renderer/store/search/state'
+import type { AlbumSearchListInfo, ListInfoItem } from '@renderer/store/search/album'
+import { search as searchAlbum, listInfos } from '@renderer/store/search/album'
+
+export type SearchSource = LX.OnlineSource | 'all'
+
+export default () => {
+  const listRef = ref<any>(null)
+
+  const listInfo = ref<AlbumSearchListInfo>({
+    page: 1,
+    limit: 30,
+    total: 0,
+    list: [],
+    key: null,
+    noItemLabel: '',
+    tagId: '',
+    sortId: '',
+  })
+
+  const search = (text: string, source: SearchSource, page: number) => {
+    // console.log(text, source, page)
+    const sourceListInfo = listInfos[source]
+    if (!sourceListInfo) return
+    listInfo.value = sourceListInfo as AlbumSearchListInfo
+    if (text.length) void addHistoryWord(text)
+    void searchAlbum(text, page, source).then((list: ListInfoItem[]) => {
+      // console.log(list)
+      if (listInfo.value.key == window.lx.songListInfo.searchKey && window.lx.songListInfo.searchPosition) {
+        void nextTick(() => {
+          listRef.value?.scrollTo(window.lx.songListInfo.searchPosition)
+        })
+      } else if (list.length && listRef.value) {
+        window.lx.songListInfo.searchKey = null
+        void nextTick(() => {
+          listRef.value.scrollTo(0)
+        })
+      }
+    })
+  }
+
+  onBeforeRouteLeave(() => {
+    window.lx.songListInfo.searchKey = listInfo.value.key
+    if (listRef.value) window.lx.songListInfo.searchPosition = listRef.value.getScrollTop()
+  })
+
+
+  return {
+    listRef,
+    listInfo,
+    search,
+  }
+}

--- a/src/renderer/views/Search/index.vue
+++ b/src/renderer/views/Search/index.vue
@@ -6,6 +6,7 @@
     </div>
     <div :class="$style.main">
       <song-list-list v-if="searchType == 'songlist'" v-show="searchText" :page="page" :source-id="source" />
+      <album-list v-else-if="searchType == 'album'" v-show="searchText" :page="page" :source-id="source" />
       <music-list v-else v-show="searchText" :page="page" :source-id="source" />
       <blank-view :visible="!searchText" :source="source" />
     </div>
@@ -17,9 +18,12 @@ import { useRoute, useRouter } from '@common/utils/vueRouter'
 import { searchText } from '@renderer/store/search/state'
 import { getSearchSetting, setSearchSetting } from '@renderer/utils/data'
 import { sources as _sources } from '@renderer/store/search/music'
+import { sources as _songlistSources } from '@renderer/store/search/songlist'
+import { sources as _albumSources } from '@renderer/store/search/album'
 
 import MusicList from './MusicList/index.vue'
 import SongListList from './SongListList/index.vue'
+import AlbumList from './AlbumList/index.vue'
 import BlankView from './components/BlankView.vue'
 import { computed, ref } from '@common/utils/vueTools'
 import { sourceNames } from '@renderer/store'
@@ -27,6 +31,8 @@ import { sourceNames } from '@renderer/store'
 const source = ref('kw')
 const searchType = ref(null)
 const page = ref(1)
+
+const getSupportList = (type) => type == 'songlist' ? _songlistSources : type == 'album' ? _albumSources : _sources
 
 const verifyQueryParams = async(to, from, next) => {
   let _source = to.query.source
@@ -38,6 +44,15 @@ const verifyQueryParams = async(to, from, next) => {
     _source ??= setting.source
     _type ??= setting.type
 
+    next({
+      path: to.path,
+      query: { ...to.query, source: _source, type: _type, page: _page },
+    })
+    return
+  }
+  // 若当前源不支持该子页签类型，则自动回退到歌曲子页签
+  if (!getSupportList(_type).includes(_source)) {
+    _type = 'music'
     next({
       path: to.path,
       query: { ...to.query, source: _source, type: _type, page: _page },
@@ -61,6 +76,7 @@ export default {
   components: {
     MusicList,
     SongListList,
+    AlbumList,
     BlankView,
   },
   beforeRouteEnter: verifyQueryParams,
@@ -69,35 +85,46 @@ export default {
     const route = useRoute()
     const router = useRouter()
 
-    const sources = _sources.map(id => {
-      return {
-        id,
-        label: sourceNames.value[id],
-      }
+    const sources = computed(() => {
+      return _sources.map(id => {
+        return {
+          id,
+          label: sourceNames.value[id],
+        }
+      })
     })
     const handleSourceChange = (id) => {
+      // 若当前源不支持当前子页签类型，则自动回退到歌曲子页签
+      const type = getSupportList(searchType.value).includes(id) ? searchType.value : 'music'
       void router.replace({
         path: route.path,
         query: {
           ...route.query,
           source: id,
+          type,
           page: 1,
         },
       })
     }
 
     const searchTypes = computed(() => {
-      return [
+      const list = [
         { label: window.i18n.t('search__type_music'), id: 'music' },
         { label: window.i18n.t('search__type_songlist'), id: 'songlist' },
+        { label: window.i18n.t('search__type_album'), id: 'album' },
       ]
+      // mg 源不支持专辑搜索，处于 mg 页签时隐藏专辑子页签
+      return source.value == 'mg' ? list.filter(item => item.id != 'album') : list
     })
     const handleTypeChange = (type) => {
+      const list = getSupportList(type)
+      const _source = list.includes(source.value) ? source.value : list[0]
       void router.replace({
         path: route.path,
         query: {
           ...route.query,
           type,
+          source: _source,
           page: 1,
         },
       })


### PR DESCRIPTION
# PR: 搜索结果页新增「专辑」子页签

## 概述
搜索结果页（`/search`）在原有「歌曲 / 歌单」页签基础上新增「专辑」页签，支持按关键词搜索 wy / kw / kg / tx 四个音乐源的专辑，以网格卡片展示并支持分页；点击专辑卡片复用现有 `/songList/detail` 详情页展示并播放专辑歌曲，无新增路由。

## 演示
<img width="920" height="600" alt="image" src="https://github.com/user-attachments/assets/e959b974-4b60-4a12-bf0d-fec39e900888" />

<img width="920" height="600" alt="image" src="https://github.com/user-attachments/assets/65ce9b62-bf79-4ba8-a154-25aed8645b75" />

## 说明
全程使用vibe coding开发，实现细节见文档doc/album-search.md。已成功打出windows unpack包，自用中。

## 关联issue
#2439 #1256 #2608 #1930 #1373 #2047 #1052 #160 等

